### PR TITLE
Update the README.md file to link to the correct backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Next.js + React app enabeling the vision of **upload anything, search everything, get answers.**
 
-👉 See the backend here: https://github.com/UIUC-Chatbot/ai-teaching-assistant-uiuc
+👉 See the backend here: https://github.com/UIUC-Chatbot/ai-ta-backend
 
 👉 See the version 1 (a Gradio app) for our inspiration: https://github.com/UIUC-Chatbot/ai-teaching-assistant-uiuc
 


### PR DESCRIPTION
Changed the link of the backend repo to the right backend repo link.

The link provided previously leads to the original AI TA backend with Gradio, and not the one based on GPT-4.