### PR TITLE
Making GPT-4-128k default model from Azure

### DIFF
--- a/src/components/UIUC-Components/EditCourseCard.tsx
+++ b/src/components/UIUC-Components/EditCourseCard.tsx
@@ -108,6 +108,7 @@ const EditCourseCard = ({
   const [isIntroMessageUpdated, setIsIntroMessageUpdated] = useState(false)
   const [loadinSpinner, setLoadinSpinner] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
+  const [isKeyUpdating, setIsKeyUpdating] = useState(false)
   const [apiKey, setApiKey] = useState<string | undefined>(
     courseMetadata?.openai_api_key as string,
   )
@@ -175,6 +176,7 @@ const EditCourseCard = ({
   }
 
   const handleKeyUpdate = async (inputValue: string, isAzure: boolean) => {
+    setIsKeyUpdating(true) // Start loading
     if (inputValue === '' && courseMetadata?.openai_api_key === '') {
       console.log('Key already empty')
       notifications.show({
@@ -192,7 +194,7 @@ const EditCourseCard = ({
     }
 
     if (inputValue === '' && courseMetadata?.openai_api_key !== '') {
-      ;(courseMetadata as CourseMetadata).openai_api_key = inputValue
+      ; (courseMetadata as CourseMetadata).openai_api_key = inputValue
       console.log('Removing api key')
       setApiKey(inputValue)
       await callSetCourseMetadata(course_name, courseMetadata as CourseMetadata)
@@ -262,6 +264,7 @@ const EditCourseCard = ({
         loading: false,
       })
       setIsEditing(false)
+      setIsKeyUpdating(false)
     }
   }
 
@@ -309,13 +312,11 @@ const EditCourseCard = ({
                   autoFocus
                   disabled={!is_new_course}
                   className={`input-bordered input w-[70%] rounded-lg border-2 border-solid bg-gray-800 lg:w-[50%] 
-                                ${
-                                  isCourseAvailable && courseName != ''
-                                    ? 'border-2 border-green-500 text-green-500 focus:border-green-500'
-                                    : 'border-red-800 text-red-600 focus:border-red-800'
-                                } ${
-                    montserrat_paragraph.variable
-                  } font-montserratParagraph`}
+                                ${isCourseAvailable && courseName != ''
+                      ? 'border-2 border-green-500 text-green-500 focus:border-green-500'
+                      : 'border-red-800 text-red-600 focus:border-red-800'
+                    } ${montserrat_paragraph.variable
+                    } font-montserratParagraph`}
                 />
                 <Title
                   order={4}
@@ -509,10 +510,10 @@ const EditCourseCard = ({
                           }}
                           size="sm"
                           radius={'xl'}
-                          className="min-w-[5rem] -translate-x-1 transform rounded-s-md bg-purple-800 text-white hover:border-indigo-600 hover:bg-indigo-600 hover:text-white focus:shadow-none focus:outline-none"
+                          className={`min-w-[5rem] -translate-x-1 transform rounded-s-md ${isKeyUpdating? 'bg-indigo-600' : 'bg-purple-800'} text-white hover:border-indigo-600 hover:bg-indigo-600 hover:text-white focus:shadow-none focus:outline-none`}
                           w={'auto'}
                         >
-                          Submit
+                          {isKeyUpdating ? <LoadingSpinner size={'sm'} /> : 'Submit'}
                         </Button>
                       }
                       rightSectionWidth={'auto'}
@@ -534,11 +535,11 @@ const EditCourseCard = ({
                   course_name={course_name}
                   current_user_email={current_user_email}
                   courseMetadata={courseMetadata as CourseMetadata}
-                  // course_intro_message={
-                  //   courseMetadata?.course_intro_message || ''
-                  // }
-                  // is_private={courseMetadata?.is_private || false}
-                  // banner_image_s3={courseBannerUrl}
+                // course_intro_message={
+                //   courseMetadata?.course_intro_message || ''
+                // }
+                // is_private={courseMetadata?.is_private || false}
+                // banner_image_s3={courseBannerUrl}
                 />
 
                 <Title
@@ -823,7 +824,7 @@ const PrivateOrPublicCourse = ({
                 href="/privacy"
                 target="_blank"
                 rel="noopener noreferrer"
-                // style={{ textDecoration: 'underline' }}
+              // style={{ textDecoration: 'underline' }}
               >
                 strict security policy
               </a>{' '}
@@ -837,9 +838,8 @@ const PrivateOrPublicCourse = ({
 
       <Group className="p-3">
         <Checkbox
-          label={`Course is ${
-            isPrivate ? 'private' : 'public'
-          }. Click to change.`}
+          label={`Course is ${isPrivate ? 'private' : 'public'
+            }. Click to change.`}
           wrapperProps={{}}
           // description="Course is private by default."
           aria-label="Checkbox to toggle Course being public or private. Private requires a list of allowed email addresses."

--- a/src/pages/api/models.ts
+++ b/src/pages/api/models.ts
@@ -80,16 +80,18 @@ const handler = async (req: Request): Promise<Response> => {
 
     const json = await response.json()
 
-    const uniqueModels: string[] = Array.from(new Set(json.data.map((model: any) => apiType === 'azure' ? model.model : model.id)));
+    const uniqueModels: string[] = Array.from(new Set(json.data.map((model: any) => model.id)));
+
+    // console.log('Unique models: ', uniqueModels)
 
     const models: OpenAIModel[] = uniqueModels
       .map((modelId: string) => {
-        const model = json.data.find((m: any) => (apiType === 'azure' ? m.model : m.id) === modelId);
-        if (!model) return undefined;
 
-        const model_name = apiType === 'azure' ? model.model : model.id;
+        const model = json.data.find((m: any) => m.id === modelId);
+        if (!model) return undefined;
+        
         for (const [key, value] of Object.entries(OpenAIModelID)) {
-          if (value === model_name) {
+          if (value === model.id) {
             return {
               id: model.id,
               name: OpenAIModels[value].name,
@@ -101,6 +103,8 @@ const handler = async (req: Request): Promise<Response> => {
         return undefined;
       })
       .filter((model): model is OpenAIModel => model !== undefined);
+
+      // console.log('Final list of Models: ', models)
 
     return new Response(JSON.stringify(models), { status: 200 })
   } catch (error) {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -15,7 +15,7 @@ export enum OpenAIModelID {
   GPT_4_VISION = 'gpt-4-vision-preview',
   // GPT_4_32K = 'gpt-4-32k',
   // Azure -- ONLY GPT-4 supported for now... due to deployment param being env var...
-  GPT_4_AZURE = 'gpt-4-from-canada-east',
+  GPT_4_AZURE = 'gpt-4-128k',
   // GPT_3_5_AZ = 'gpt-35-turbo',
   // GPT_3_5_16k_AZURE = 'gpt-35-turbo-16k'
 }
@@ -72,7 +72,7 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     id: OpenAIModelID.GPT_4_AZURE,
     name: 'GPT-4 Azure',
     maxLength: 24000,
-    tokenLimit: 8192,
+    tokenLimit: 128000,
   },
   [OpenAIModelID.GPT_4_VISION]: {
     id: OpenAIModelID.GPT_4_VISION,

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -26,19 +26,19 @@ export const fallbackModelID = OpenAIModelID.GPT_4
 export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   [OpenAIModelID.GPT_3_5]: {
     id: OpenAIModelID.GPT_3_5,
-    name: 'GPT-3.5 Turbo',
+    name: 'GPT-3.5 (4k)',
     maxLength: 12000,
     tokenLimit: 4096,
   },
   [OpenAIModelID.GPT_3_5_16k]: {
     id: OpenAIModelID.GPT_3_5_16k,
-    name: 'GPT-3.5 (16k large context)',
+    name: 'GPT-3.5 (16k)',
     maxLength: 49000,
     tokenLimit: 16385,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,
-    name: 'GPT-4',
+    name: 'GPT-4 (8k)',
     maxLength: 24000,
     tokenLimit: 8192,
   },
@@ -70,7 +70,7 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   // },
   [OpenAIModelID.GPT_4_AZURE]: {
     id: OpenAIModelID.GPT_4_AZURE,
-    name: 'GPT-4 Azure',
+    name: 'GPT-4 Turbo (128k)',
     maxLength: 24000,
     tokenLimit: 128000,
   },

--- a/src/utils/server/index.ts
+++ b/src/utils/server/index.ts
@@ -69,7 +69,7 @@ export const OpenAIStream = async (
 
   let url = `${endpoint}/v1/chat/completions`
   if (apiType === 'azure') {
-    const deploymentName = process.env.AZURE_OPENAI_ENGINE
+    const deploymentName = model.id || process.env.AZURE_OPENAI_ENGINE
     url = `${endpoint}/openai/deployments/${deploymentName}/chat/completions?api-version=${OPENAI_API_VERSION}`
   }
 


### PR DESCRIPTION
1. Making the default azure supported model as gpt-4-128k, managed from @openai.ts
2. Removed dependency on env AZURE_OPENAI_ENGINE, fetching deployments while validating key
3. Added a loader due to an added api call. Assumption: ValidateKey always uses 1st deployment for validation or falls back to env
Assumption: ValidateKey always uses 1st deployment for validation or falls back to env
