### PR TITLE
Default to GPT-4 Vision model if available, add new GPT-4-0125 support

### DIFF
--- a/src/pages/api/home/home.tsx
+++ b/src/pages/api/home/home.tsx
@@ -303,7 +303,7 @@ const Home = () => {
     }
 
     // Ordered list of preferred model IDs
-    const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-1106-preview', 'gpt-4'];
+    const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-1106-preview', 'gpt-4', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo'];
 
     // Find and return the first available preferred model
     for (const preferredId of preferredModelIds) {

--- a/src/pages/api/home/home.tsx
+++ b/src/pages/api/home/home.tsx
@@ -303,7 +303,7 @@ const Home = () => {
     }
 
     // Ordered list of preferred model IDs
-    const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-1106-preview', 'gpt-4', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo'];
+    const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-0125-preview', 'gpt-4-1106-preview', 'gpt-4', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo'];
 
     // Find and return the first available preferred model
     for (const preferredId of preferredModelIds) {

--- a/src/pages/api/home/home.tsx
+++ b/src/pages/api/home/home.tsx
@@ -49,7 +49,6 @@ const Home = () => {
   const { getModelsError } = useErrorService()
   const [isLoading, setIsLoading] = useState<boolean>(true) // Add a new state for loading
 
-  const defaultModelId = OpenAIModelID.GPT_4
   const serverSidePluginKeysSet = true
 
   const contextValue = useCreateReducer<HomeInitialState>({
@@ -83,11 +82,8 @@ const Home = () => {
   )
 
   useEffect(() => {
-    // Set model (to only available models)
-    const modelId = selectedConversation?.model.id
-    console.log("In effect of home, selectedConversation model id: ", modelId)
-    const lastConversation = conversations[conversations.length - 1]
-    const model = selectBestModel(lastConversation, models, defaultModelId);
+    // Set model after we fetch available models
+    const model = selectBestModel();
 
     dispatch({
       field: 'defaultModelId',
@@ -98,13 +94,11 @@ const Home = () => {
     if (selectedConversation) {
       const convo_with_valid_model = selectedConversation
       convo_with_valid_model.model = model
-      console.debug("IN ENSURE CURRENT CONVO HAS A VALID MODEL, USING MODEL: ", model)
       dispatch({
         field: 'selectedConversation',
         value: convo_with_valid_model,
       })
     }
-    // console.debug("In effect of home Using model: ", defaultModel)
   }, [models])
 
 
@@ -300,39 +294,36 @@ const Home = () => {
     saveFolders(updatedFolders)
   }
 
+  const selectBestModel = (): OpenAIModel => {
+    const defaultModelId = OpenAIModelID.GPT_4_VISION
 
-  const selectBestModel = (lastConversation: Conversation | undefined, models: OpenAIModel[], defaultModelId: OpenAIModelID): OpenAIModel => {
-    // If models array is empty, return defaultModelId
-    if (!models.length) {
-      return OpenAIModels[defaultModelId]
+    // Return the default model if the models array is empty
+    if (models.length === 0) {
+      return OpenAIModels[defaultModelId];
     }
 
-    // If the last conversation's model is available, use it
-    if (lastConversation && lastConversation.model && models.some(model => model.id === lastConversation.model.id)) {
-      return lastConversation.model as OpenAIModel;
-    } else {
-      // If 'gpt-4-from-canada-east' or 'gpt-4' are available, use whichever is available
-      const preferredModel = models.find(model => ['gpt-4-from-canada-east', 'gpt-4'].includes(model.id));
+    // Ordered list of preferred model IDs
+    const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-1106-preview', 'gpt-4'];
 
-      if (preferredModel) {
-        return preferredModel;
-      } else {
-        // Fallback to the default model
-        return models.find((model) => model.id === defaultModelId) || models[0] || OpenAIModels[defaultModelId];
+    // Find and return the first available preferred model
+    for (const preferredId of preferredModelIds) {
+      const model = models.find(m => m.id === preferredId);
+      if (model) {
+        return model;
       }
     }
+
+    // Fallback to the first model in the list or the default model
+    return models[0] || OpenAIModels[defaultModelId];
   }
 
   // CONVERSATION OPERATIONS  --------------------------------------------
 
   const handleNewConversation = () => {
     const lastConversation = conversations[conversations.length - 1]
-    console.debug("Models available: ", models)
-    console.debug("IN NEW CONVERSATION Using model: ", defaultModelId)
 
     // Determine the model to use for the new conversation
-    const model = selectBestModel(lastConversation, models, defaultModelId);
-    console.debug('NEW CONVO : handleNewConversation SETTING IT TO: ', model);
+    const model = selectBestModel();
 
     const newConversation: Conversation = {
       id: uuidv4(),
@@ -460,14 +451,14 @@ const Home = () => {
   }, [selectedConversation])
 
   useEffect(() => {
-    defaultModelId &&
-      dispatch({ field: 'defaultModelId', value: defaultModelId })
+    // defaultModelId &&
+    //   dispatch({ field: 'defaultModelId', value: defaultModelId })
     serverSidePluginKeysSet &&
       dispatch({
         field: 'serverSidePluginKeysSet',
         value: serverSidePluginKeysSet,
       })
-  }, [defaultModelId, serverSidePluginKeysSet]) // serverSideApiKeyIsSet,
+  }, [serverSidePluginKeysSet]) // defaultModelId, 
 
   // ON LOAD --------------------------------------------
 
@@ -533,18 +524,19 @@ const Home = () => {
     } else {
       const lastConversation = conversations[conversations.length - 1]
       console.debug("Models available: ", models)
-      let defaultModel = models.find(model => model.id === 'gpt-4-from-canada-east' || model.id === 'gpt-4') || models[0]
-      if (!defaultModel) {
-        defaultModel = OpenAIModels['gpt-4']
-      }
-      console.debug("Using model: ", defaultModel)
+      // let defaultModel = models.find(model => model.id === 'gpt-4-from-canada-east' || model.id === 'gpt-4') || models[0]
+      const bestModel = selectBestModel();
+      // if (!defaultModel) {
+      //   defaultModel = OpenAIModels['gpt-4']
+      // }
+      console.debug("Using model: ", bestModel)
       dispatch({
         field: 'selectedConversation',
         value: {
           id: uuidv4(),
           name: t('New Conversation'),
           messages: [],
-          model: defaultModel,
+          model: bestModel,
           prompt: DEFAULT_SYSTEM_PROMPT,
           temperature: lastConversation?.temperature ?? DEFAULT_TEMPERATURE,
           folderId: null,

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -85,6 +85,6 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     id: OpenAIModelID.GPT_4_VISION,
     name: 'GPT-4 Vision',
     maxLength: 8000,
-    tokenLimit: 110000, // TPM of 40,000 -- so have to reduce this, despite it supporting up to 128k
+    tokenLimit: 110000, // slightly less to account for possible images 
   },
 }

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -12,6 +12,7 @@ export enum OpenAIModelID {
   GPT_3_5_16k = 'gpt-3.5-turbo-16k',
   GPT_4 = 'gpt-4',
   GPT_4_1106_PREVIEW = 'gpt-4-1106-preview',
+  GPT_4_0125_PREVIEW = 'gpt-4-0125-preview',
   GPT_4_VISION = 'gpt-4-vision-preview',
   // GPT_4_32K = 'gpt-4-32k',
   // Azure -- ONLY GPT-4 supported for now... due to deployment param being env var...
@@ -44,7 +45,13 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   },
   [OpenAIModelID.GPT_4_1106_PREVIEW]: {
     id: OpenAIModelID.GPT_4_1106_PREVIEW,
-    name: 'GPT-4 Turbo (128k)',
+    name: 'GPT-4 Turbo 1106 (128k)',
+    maxLength: 24000,
+    tokenLimit: 128000,
+  },
+  [OpenAIModelID.GPT_4_0125_PREVIEW]: {
+    id: OpenAIModelID.GPT_4_0125_PREVIEW,
+    name: 'GPT-4 Turbo 0125 (128k)',
     maxLength: 24000,
     tokenLimit: 128000,
   },
@@ -78,6 +85,6 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     id: OpenAIModelID.GPT_4_VISION,
     name: 'GPT-4 Vision',
     maxLength: 8000,
-    tokenLimit: 15000, // TPM of 40,000 -- so have to reduce this, despite it supporting up to 128k
+    tokenLimit: 110000, // TPM of 40,000 -- so have to reduce this, despite it supporting up to 128k
   },
 }


### PR DESCRIPTION
Here's the order of model priorities we'll try 

`const preferredModelIds = ['gpt-4-vision-preview', 'gpt-4-128k', 'gpt-4-0125-preview', 'gpt-4-1106-preview', 'gpt-4', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo'];`

https://github.com/KastanDay/ai-ta-frontend/pull/102/files#diff-c033909adbcccea1c297b91ba4ce399c6d0bd8e1f8959fa313f48d2cba5dfffaR306

Vision > 4 Turbo > 4 > 3.5 (16k) > 3.5 (4k)