### PR TITLE
Improve Default Model on /chat page; respect previous choices, and the prioritized list of defaults

### DIFF
--- a/src/components/Chat/ModelSelect.tsx
+++ b/src/components/Chat/ModelSelect.tsx
@@ -20,7 +20,10 @@ import {
   preferredModelIds,
   selectBestModel,
 } from '~/types/openai'
-import ChatUI, { webLLMModels, WebLLMLoadingState } from '~/utils/modelProviders/WebLLM'
+import ChatUI, {
+  webLLMModels,
+  WebLLMLoadingState,
+} from '~/utils/modelProviders/WebLLM'
 import { modelCached } from './UserSettings'
 import Image from 'next/image'
 import { LLMProvider, ProviderNames } from '~/types/LLMProvider'
@@ -91,7 +94,13 @@ const getModelLogo = (modelType: string) => {
       throw new Error(`Unknown model type: ${modelType}`)
   }
 }
-const ModelItem = forwardRef<HTMLDivElement, ModelItemProps & { loadingModelId: string | null, setLoadingModelId: (id: string | null) => void }>(
+const ModelItem = forwardRef<
+  HTMLDivElement,
+  ModelItemProps & {
+    loadingModelId: string | null
+    setLoadingModelId: (id: string | null) => void
+  }
+>(
   (
     {
       label,
@@ -105,7 +114,10 @@ const ModelItem = forwardRef<HTMLDivElement, ModelItemProps & { loadingModelId: 
       setLoadingModelId,
       chat_ui,
       ...others
-    }: ModelItemProps & { loadingModelId: string | null, setLoadingModelId: (id: string | null) => void },
+    }: ModelItemProps & {
+      loadingModelId: string | null
+      setLoadingModelId: (id: string | null) => void
+    },
     ref,
   ) => {
     const [isModelCached, setIsModelCached] = useState(false)
@@ -182,23 +194,57 @@ const ModelItem = forwardRef<HTMLDivElement, ModelItemProps & { loadingModelId: 
                 <Text size="xs" opacity={0.65}>
                   {downloadSize}
                 </Text>
-                {state.webLLMModelIdLoading.id == modelId && state.webLLMModelIdLoading.isLoading ? (
-                  <div style={{ marginLeft: '8px', display: 'flex', alignItems: 'center' }}>
+                {state.webLLMModelIdLoading.id == modelId &&
+                state.webLLMModelIdLoading.isLoading ? (
+                  <div
+                    style={{
+                      marginLeft: '8px',
+                      display: 'flex',
+                      alignItems: 'center',
+                    }}
+                  >
                     <LoadingSpinner size="0.5rem" />
-                    <Text size="s" style={{ marginLeft: '7px' }} className="text-purple-600">loading</Text>
+                    <Text
+                      size="s"
+                      style={{ marginLeft: '7px' }}
+                      className="text-purple-600"
+                    >
+                      loading
+                    </Text>
                   </div>
                 ) : (
                   <>
-                    {isModelCached || state.webLLMModelIdLoading.id == modelId && !state.webLLMModelIdLoading.isLoading ? (
+                    {isModelCached ||
+                    (state.webLLMModelIdLoading.id == modelId &&
+                      !state.webLLMModelIdLoading.isLoading) ? (
                       <>
-                        <IconCircleCheck size="1rem" style={{ marginLeft: '8px' }} className='text-purple-400' />
+                        <IconCircleCheck
+                          size="1rem"
+                          style={{ marginLeft: '8px' }}
+                          className="text-purple-400"
+                        />
                         {/* {isLoading && setLoadingModelId(null)} */}
                       </>
                     ) : (
                       <IconDownload size="1rem" style={{ marginLeft: '8px' }} />
                     )}
-                    <Text size="xs" opacity={isModelCached ? 1 : 0.65} style={{ marginLeft: '4px' }} className={isModelCached || state.webLLMModelIdLoading.id == modelId && !state.webLLMModelIdLoading.isLoading ? 'text-purple-400' : ''}>
-                      {isModelCached || state.webLLMModelIdLoading.id == modelId && !state.webLLMModelIdLoading.isLoading ? 'downloaded' : 'download'}
+                    <Text
+                      size="xs"
+                      opacity={isModelCached ? 1 : 0.65}
+                      style={{ marginLeft: '4px' }}
+                      className={
+                        isModelCached ||
+                        (state.webLLMModelIdLoading.id == modelId &&
+                          !state.webLLMModelIdLoading.isLoading)
+                          ? 'text-purple-400'
+                          : ''
+                      }
+                    >
+                      {isModelCached ||
+                      (state.webLLMModelIdLoading.id == modelId &&
+                        !state.webLLMModelIdLoading.isLoading)
+                        ? 'downloaded'
+                        : 'download'}
                     </Text>
                   </>
                 )}
@@ -238,7 +284,12 @@ const ModelItem = forwardRef<HTMLDivElement, ModelItemProps & { loadingModelId: 
   },
 )
 
-const ModelDropdown: React.FC<ModelDropdownProps & { setLoadingModelId: (id: string | null) => void, onChange: (modelId: string) => Promise<void> }> = ({
+const ModelDropdown: React.FC<
+  ModelDropdownProps & {
+    setLoadingModelId: (id: string | null) => void
+    onChange: (modelId: string) => Promise<void>
+  }
+> = ({
   title,
   value,
   onChange,
@@ -315,7 +366,13 @@ const ModelDropdown: React.FC<ModelDropdownProps & { setLoadingModelId: (id: str
             group: model.group,
             vram_required_MB: model.vram_required_MB,
           }))}
-          itemComponent={(props) => <ModelItem {...props} loadingModelId={loadingModelId} setLoadingModelId={setLoadingModelId} />}
+          itemComponent={(props) => (
+            <ModelItem
+              {...props}
+              loadingModelId={loadingModelId}
+              setLoadingModelId={setLoadingModelId}
+            />
+          )}
           maxDropdownHeight={480}
           rightSectionWidth="auto"
           icon={
@@ -393,7 +450,7 @@ export const ModelSelect = React.forwardRef<HTMLDivElement, any>(
       dispatch: homeDispatch,
     } = useContext(HomeContext)
     const isSmallScreen = useMediaQuery('(max-width: 960px)')
-    const defaultModel = selectBestModel(llmProviders).id
+    const defaultModel = selectBestModel(llmProviders, selectedConversation).id
     const [loadingModelId, setLoadingModelId] = useState<string | null>(null)
 
     const handleModelClick = (modelId: string) => {
@@ -419,7 +476,6 @@ export const ModelSelect = React.forwardRef<HTMLDivElement, any>(
           key: 'model',
           value: model as OpenAIModel,
         })
-
     }
 
     return (
@@ -439,7 +495,9 @@ export const ModelSelect = React.forwardRef<HTMLDivElement, any>(
                 // //   console.log('model is loading', state.webLLMModelIdLoading.id)
                 // // }
                 // await handleModelClick(modelId)
-                async (modelId) => { handleModelClick(modelId) }
+                async (modelId) => {
+                  handleModelClick(modelId)
+                }
               }
               models={{
                 Ollama: llmProviders.Ollama?.models?.filter(
@@ -574,8 +632,9 @@ export const ModelSelect = React.forwardRef<HTMLDivElement, any>(
                 />
               </Link>
               <br />
-              If you see lots of text, it&apos;s working. If you see &quot;webgpu not
-              available on this browser&quot;, it&apos;s not working.
+              If you see lots of text, it&apos;s working. If you see
+              &quot;webgpu not available on this browser&quot;, it&apos;s not
+              working.
             </Text>
             <Title
               className={`pb-1 pl-4 pt-2 ${montserrat_heading.variable} font-montserratHeading`}

--- a/src/components/Chat/UserSettings.tsx
+++ b/src/components/Chat/UserSettings.tsx
@@ -76,10 +76,7 @@ export const UserSettings = () => {
     //   webLLMModels.some((m) => m.name === model.name)
     // ) {
     for (const model of webLLMModels) {
-      const theCachedModel = await webllm.hasModelInCache(
-        model.name,
-        appConfig,
-      )
+      const theCachedModel = await webllm.hasModelInCache(model.name, appConfig)
       if (theCachedModel) {
         if (
           !modelCached.some((cachedModel) => cachedModel.name === model.name)
@@ -88,7 +85,7 @@ export const UserSettings = () => {
         }
         // console.log('model is cached:', model.name)
       }
-      console.log('hasModelInCache: ', modelCached)
+      // console.log('hasModelInCache: ', modelCached)
     }
     // }
   }

--- a/src/pages/api/home/home.tsx
+++ b/src/pages/api/home/home.tsx
@@ -90,7 +90,7 @@ const Home = () => {
 
   useEffect(() => {
     // Set model after we fetch available models
-    const model = selectBestModel(llmProviders)
+    const model = selectBestModel(llmProviders, selectedConversation)
 
     dispatch({
       field: 'defaultModelId',
@@ -309,7 +309,7 @@ const Home = () => {
     const lastConversation = conversations[conversations.length - 1]
 
     // Determine the model to use for the new conversation
-    const model = selectBestModel(llmProviders)
+    const model = selectBestModel(llmProviders, lastConversation)
 
     const newConversation: Conversation = {
       id: uuidv4(),
@@ -558,13 +558,7 @@ const Home = () => {
       })
     } else {
       const lastConversation = conversations[conversations.length - 1]
-      console.debug('Models available: ', llmProviders)
-      // let defaultModel = models.find(model => model.id === 'gpt-4-from-canada-east' || model.id === 'gpt-4') || models[0]
-      const bestModel = selectBestModel(llmProviders)
-      // if (!defaultModel) {
-      //   defaultModel = OpenAIModels['gpt-4']
-      // }
-      console.debug('Using model: ', bestModel)
+      const bestModel = selectBestModel(llmProviders, lastConversation)
       dispatch({
         field: 'selectedConversation',
         value: {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -1,3 +1,4 @@
+import { Conversation } from './chat'
 import {
   AllLLMProviders,
   GenericSupportedModel,
@@ -27,15 +28,26 @@ export const preferredModelIds = [
 
 export const selectBestModel = (
   allLLMProviders: AllLLMProviders,
+  convo?: Conversation,
 ): GenericSupportedModel => {
-  // Use GPT-4o-mini if available, otherwise fallback to Llama 3.1 70b
-
-  // Use the preferredModelIds, otherwise fallback to Llama 3.1 70b
   const allModels = Object.values(allLLMProviders)
     .flatMap((provider) => provider.models || [])
     .filter((model) => model.enabled)
 
-  // Find and return the first available preferred model
+  // First, try to use the model from the conversation if it exists and is valid
+  if (
+    convo &&
+    convo.model &&
+    typeof convo.model === 'object' &&
+    'id' in convo.model
+  ) {
+    const conversationModel = allModels.find((m) => m.id === convo.model.id)
+    if (conversationModel) {
+      return conversationModel
+    }
+  }
+
+  // If the conversation model is not available or invalid, use the preferredModelIds
   for (const preferredId of preferredModelIds) {
     const model = allModels.find((m) => m.id === preferredId)
     if (model) {
@@ -43,32 +55,13 @@ export const selectBestModel = (
     }
   }
 
+  // If no preferred models are available, fallback to Llama 3.1 70b
   return {
     id: 'llama3.1:70b',
     name: 'Llama 3.1 70b',
     tokenLimit: 128000,
     enabled: true,
   }
-
-  // if (
-  //   allLLMProviders?.OpenAI?.models &&
-  //   allLLMProviders.OpenAI.models.length > 0
-  // ) {
-  //   const gpt4oMini = allLLMProviders.OpenAI.models.find(
-  //     (model) => model.id === 'gpt-4o-mini',
-  //   )
-  //   if (gpt4oMini) {
-  //     return gpt4oMini
-  //   }
-  // }
-  // const defaultModelId = OpenAIModelID.GPT_4o
-  // return OpenAIModels[defaultModelId]
-  // if (!models || !models.OpenAI) {
-  //   return OpenAIModels[defaultModelId]
-  // }
-
-  // // Fallback to the first model in the list or the default model
-  // return models.OpenAI[0] || OpenAIModels[defaultModelId]
 }
 
 export enum OpenAIModelID {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -30,35 +30,41 @@ export const selectBestModel = (
 ): GenericSupportedModel => {
   // Use GPT-4o-mini if available, otherwise fallback to Llama 3.1 70b
 
-  if (
-    allLLMProviders?.OpenAI?.models &&
-    allLLMProviders.OpenAI.models.length > 0
-  ) {
-    const gpt4oMini = allLLMProviders.OpenAI.models.find(
-      (model) => model.id === 'gpt-4o-mini',
-    )
-    if (gpt4oMini) {
-      return gpt4oMini
+  // Use the preferredModelIds, otherwise fallback to Llama 3.1 70b
+  const allModels = Object.values(allLLMProviders)
+    .flatMap((provider) => provider.models || [])
+    .filter((model) => model.enabled)
+
+  // Find and return the first available preferred model
+  for (const preferredId of preferredModelIds) {
+    const model = allModels.find((m) => m.id === preferredId)
+    if (model) {
+      return model
     }
   }
+
   return {
     id: 'llama3.1:70b',
     name: 'Llama 3.1 70b',
     tokenLimit: 128000,
     enabled: true,
   }
+
+  // if (
+  //   allLLMProviders?.OpenAI?.models &&
+  //   allLLMProviders.OpenAI.models.length > 0
+  // ) {
+  //   const gpt4oMini = allLLMProviders.OpenAI.models.find(
+  //     (model) => model.id === 'gpt-4o-mini',
+  //   )
+  //   if (gpt4oMini) {
+  //     return gpt4oMini
+  //   }
+  // }
   // const defaultModelId = OpenAIModelID.GPT_4o
   // return OpenAIModels[defaultModelId]
   // if (!models || !models.OpenAI) {
   //   return OpenAIModels[defaultModelId]
-  // }
-
-  // // Find and return the first available preferred model
-  // for (const preferredId of preferredModelIds) {
-  //   const model = models.OpenAI.find((m) => m.id === preferredId)
-  //   if (model) {
-  //     return model
-  //   }
   // }
 
   // // Fallback to the first model in the list or the default model


### PR DESCRIPTION
* Respect previous choices. E.g. the "last selected model" will attempt to be used, fallback to the preference list.
* Respect enabled/disabled models when selecting the default
* Bugfix: gpt-4o-mini can now be disabled, previously that one model bypassed checks.
* Bonus: this makes WebLLM (local models) even better. They don't have to re-load between new conversations. 