### PR TITLE
Fix LaTeX Equation Rendering

### DIFF
--- a/src/app/utils/buildPromptUtils.ts
+++ b/src/app/utils/buildPromptUtils.ts
@@ -381,7 +381,16 @@ const _getSystemPrompt = async ({
   }
 
   // If userDefinedSystemPrompt is null or undefined, use DEFAULT_SYSTEM_PROMPT
-  const systemPrompt = userDefinedSystemPrompt ?? DEFAULT_SYSTEM_PROMPT ?? ''
+  let systemPrompt = userDefinedSystemPrompt ?? DEFAULT_SYSTEM_PROMPT ?? ''
+
+  // Necessary for math notation. See https://docs.mathjax.org/en/latest/input/tex/index.html
+  systemPrompt += `\nWhen responding with equations, use MathJax/KaTeX notation. Equations should be wrapped in either:
+
+  * Single dollar signs $...$ for inline math
+  * Double dollar signs $$...$$ for display/block math
+  * Or \\[...\\] for display math
+  
+  Here's how the equations should be formatted in the markdown: Schrödinger Equation: $i\\hbar \\frac{\\partial}{\\partial t} \\Psi(\\mathbf{r}, t) = \\hat{H} \\Psi(\\mathbf{r}, t)$`
 
   // Check if contexts are present
   const contexts =
@@ -424,8 +433,8 @@ export const getSystemPostPrompt = ({
   PostPromptLines.push(
     `Please analyze and respond to the following question using the excerpts from the provided documents. These documents can be pdf files or web pages. Additionally, you may see the output from API calls (called 'tools') to the user's services which, when relevant, you should use to construct your answer. You may also see image descriptions from images uploaded by the user. Prioritize image descriptions, when helpful, to construct your answer.
 Integrate relevant information from these documents, ensuring each reference is linked to the document's number.
-Your response should be semi-formal. 
-When quoting directly, cite with footnotes linked to the document number and page number, if provided. 
+
+When quoting directly from a source document, cite with footnotes linked to the document number and page number, if provided. 
 Summarize or paraphrase other relevant information with inline citations, again referencing the document number and page number, if provided.
 If the answer is not in the provided documents, state so.${
       guidedLearning || documentsOnly

--- a/src/app/utils/ollama.ts
+++ b/src/app/utils/ollama.ts
@@ -62,10 +62,10 @@ function convertConversatonToVercelAISDKv3(
     (msg) => msg.latestSystemMessage !== undefined,
   )
   if (systemMessage) {
-    console.log(
-      'Found system message, latestSystemMessage: ',
-      systemMessage.latestSystemMessage,
-    )
+    // console.log(
+    //     'Found system message, latestSystemMessage: ',
+    //     systemMessage.latestSystemMessage,
+    // )
     coreMessages.push({
       role: 'system',
       content: systemMessage.latestSystemMessage || '',
@@ -83,7 +83,7 @@ function convertConversatonToVercelAISDKv3(
 
       // just for Llama 3.1 70b, remind it to use proper citation format.
       content +=
-        '\n\nIf you use the <Potentially Relevant Documents> in your response, please remember cite your sources using the required formatting, e.g. "The grass is green. [29, page: 11]'
+        '\nWhen writing equations, always use MathJax/KaTeX notation.\n\nIf you use the <Potentially Relevant Documents> in your response, please remember cite your sources using the required formatting, e.g. "The grass is green. [29, page: 11]'
     } else if (Array.isArray(message.content)) {
       // Combine text content from array
       content = message.content

--- a/src/pages/[course_name]/chat.tsx
+++ b/src/pages/[course_name]/chat.tsx
@@ -11,6 +11,7 @@ import { get_user_permission } from '~/components/UIUC-Components/runAuthCheck'
 import { LoadingSpinner } from '~/components/UIUC-Components/LoadingSpinner'
 import { montserrat_heading } from 'fonts'
 import { MainPageBackground } from '~/components/UIUC-Components/MainPageBackground'
+import Head from 'next/head'
 
 const ChatPage: NextPage = () => {
   const clerk_user_outer = useUser()

--- a/src/pages/api/conversation.ts
+++ b/src/pages/api/conversation.ts
@@ -119,14 +119,6 @@ export function convertChatToDBMessage(
   chatMessage: ChatMessage,
   conversationId: string,
 ): DBMessage {
-  console.log(
-    'chatMessage',
-    'for id: ',
-    conversationId,
-    'for message: ',
-    // chatMessage,
-  )
-  // console.log('chatMessage.content type: ', typeof chatMessage.content)
   let content_text = ''
   let content_image_urls: string[] = []
   let image_description = ''
@@ -201,10 +193,6 @@ export default async function handler(
       try {
         // Convert conversation to DB type
         const dbConversation = convertChatToDBConversation(conversation)
-        console.log(
-          'Saving conversation to server with db object:',
-          dbConversation,
-        )
 
         if (conversation.messages.length === 0) {
           throw new Error('No messages in conversation, not saving!')

--- a/src/utils/app/const.ts
+++ b/src/utils/app/const.ts
@@ -1,6 +1,12 @@
 export const DEFAULT_SYSTEM_PROMPT =
   process.env.NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT ||
-  "You are a helpful AI assistant. Follow instructions carefully. Respond using markdown."
+  `You are a helpful AI assistant. Follow instructions carefully. Respond using markdown. When responding with equations, use MathJax/KaTeX notation. Equations should be wrapped in either:
+
+* Single dollar signs $...$ for inline math
+* Double dollar signs $$...$$ for display/block math
+* Or \[...\] for display math
+
+Here's how the equations should be formatted in the markdown: Schrödinger Equation: $i\hbar \frac{\partial}{\partial t} \Psi(\mathbf{r}, t) = \hat{H} \Psi(\mathbf{r}, t)$`
 
 export const OPENAI_API_HOST =
   process.env.OPENAI_API_HOST || 'https://api.openai.com'


### PR DESCRIPTION
The fix is combination of prompting the LLMs to use MathJax/KaTeX notation and regex cleanup when they don't listen.