### PR TITLE
Add support for MinIO as an AWS S3 replacement

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,4 +84,4 @@ const config = {
   },
 }
 
-export default withBundleAnalyzer(bundleAnalyzerConfig)
+export default withBundleAnalyzer(bundleAnalyzerConfig)(config)

--- a/src/pages/api/UIUC-api/getPresignedUrl.ts
+++ b/src/pages/api/UIUC-api/getPresignedUrl.ts
@@ -3,19 +3,25 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-const aws_config = {
-  bucketName: 'uiuc-chatbot',
-  region: 'us-east-1',
-  accessKeyId: process.env.AWS_KEY,
-  secretAccessKey: process.env.AWS_SECRET,
-}
-
 const s3Client = new S3Client({
-  region: aws_config.region,
+  region: process.env.AWS_REGION,
   credentials: {
-    accessKeyId: process.env.AWS_KEY as string,
-    secretAccessKey: process.env.AWS_SECRET as string,
+    // @ts-ignore -- it's fine, stop complaining
+    accessKeyId: process.env.AWS_KEY,
+    // @ts-ignore -- it's fine, stop complaining
+    secretAccessKey: process.env.AWS_SECRET,
   },
+  // If MINIO_ENDPOINT is defined, use it instead of AWS S3.
+  ...(process.env.MINIO_ENDPOINT
+    ? {
+        endpoint: process.env.MINIO_ENDPOINT,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: process.env.MINIO_ACCESS_KEY,
+          secretAccessKey: process.env.MINIO_SECRET,
+        },
+      }
+    : {}),
 })
 
 export default async function handler(
@@ -26,7 +32,7 @@ export default async function handler(
     const { s3_path } = req.query
 
     const command = new GetObjectCommand({
-      Bucket: aws_config.bucketName,
+      Bucket: process.env.S3_BUCKET_NAME!,
       Key: s3_path as string,
     })
 

--- a/src/pages/api/download.ts
+++ b/src/pages/api/download.ts
@@ -3,19 +3,25 @@ import { GetObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const aws_config = {
-  bucketName: 'uiuc-chatbot',
-  region: 'us-east-1',
-  accessKeyId: process.env.AWS_KEY,
-  secretAccessKey: process.env.AWS_SECRET,
-}
-
 const s3Client = new S3Client({
-  region: aws_config.region,
+  region: process.env.AWS_REGION,
   credentials: {
-    accessKeyId: process.env.AWS_KEY as string,
-    secretAccessKey: process.env.AWS_SECRET as string,
+    // @ts-ignore -- it's fine, stop complaining
+    accessKeyId: process.env.AWS_KEY,
+    // @ts-ignore -- it's fine, stop complaining
+    secretAccessKey: process.env.AWS_SECRET,
   },
+  // If MINIO_ENDPOINT is defined, use it instead of AWS S3.
+  ...(process.env.MINIO_ENDPOINT
+    ? {
+        endpoint: process.env.MINIO_ENDPOINT,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: process.env.MINIO_ACCESS_KEY,
+          secretAccessKey: process.env.MINIO_SECRET,
+        },
+      }
+    : {}),
 })
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -36,7 +42,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     const command = new GetObjectCommand({
-      Bucket: aws_config.bucketName,
+      Bucket: process.env.S3_BUCKET_NAME!,
       Key: filePath,
       ResponseContentDisposition: 'inline',
       ResponseContentType: ResponseContentType,


### PR DESCRIPTION
If `MINIO_ENDPOINT` env var is defined, it will use MinIO instead of AWS S3. The following two credentials are still required (for either S3 or MinIO): 
* `AWS_KEY`
* `AWS_SECRET`
* `S3_BUCKET_NAME`
* Only if using AWS, this is also required `AWS_REGION`. Our region is `us-east-1`

Tested thoroughly on Prod, still using AWS. Works great. Merging, then I'll test on local to ensure we don't leak MINIO credentials. 