### PR TITLE
437 image description returns 500 internal error

### DIFF
--- a/src/pages/api/imageDescription.ts
+++ b/src/pages/api/imageDescription.ts
@@ -36,6 +36,7 @@ const handler = async (req: AuthenticatedRequest, res: NextApiResponse) => {
       messages,
       false,
     )
+    console.log('Response from OpenAIStream:', response)
 
     // Guard: ensure it's an object or string you can safely return
     if (!response || typeof response !== "object") {


### PR DESCRIPTION
Tested on vercel.
---
Need to test this on dev see if it works.
On my local I'm getting the 500 internal error and VLM docker container doesn't log specific error in the log. 
Hopefully it's related to the local minio can't be reached by the VLM machine. 