### PR TITLE
Fix s3 upload authorization for public chatbot

### DIFF
--- a/src/pages/api/UIUC-api/uploadToS3.ts
+++ b/src/pages/api/UIUC-api/uploadToS3.ts
@@ -3,7 +3,7 @@ import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post'
 import { s3Client, vyriadMinioClient } from '~/utils/s3Client'
-import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
+import { withCourseAccessFromRequest } from '~/pages/api/authorization'
 
 const handler = async (req: AuthenticatedRequest, res: NextApiResponse) => {
   try {
@@ -61,4 +61,6 @@ const handler = async (req: AuthenticatedRequest, res: NextApiResponse) => {
   }
 }
 
-export default withCourseOwnerOrAdminAccess()(handler)
+// Allow public chatbot uploads (unauthenticated) based on course metadata
+// and fall back to auth checks for private courses via the shared middleware.
+export default withCourseAccessFromRequest('any')(handler)


### PR DESCRIPTION
Update `uploadToS3` API to allow uploads for public chatbots by unauthenticated or non-member users.

---
[Slack Thread](https://aifarms.slack.com/archives/C05QL4EM9D3/p1761148050752079?thread_ts=1761148050.752079&cid=C05QL4EM9D3)

<a href="https://cursor.com/background-agent?bcId=bc-a6a399f0-8d29-41fe-89ac-39f23534b09a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6a399f0-8d29-41fe-89ac-39f23534b09a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

