### PR TITLE
if local don't enable ssl

### DIFF
--- a/src/db/dbClient.ts
+++ b/src/db/dbClient.ts
@@ -6,9 +6,15 @@ import * as schema from './schema'
 const connectionString = `postgres://${process.env.POSTGRES_USERNAME}:${process.env.POSTGRES_PASSWORD}@${process.env.POSTGRES_ENDPOINT}:${process.env.POSTGRES_PORT}/${process.env.POSTGRES_DATABASE}`
 const keycloakDBConnectionString = `postgres://${process.env.KEYCLOAK_DB_USERNAME}:${process.env.KEYCLOAK_DB_PASSWORD}@${process.env.KEYCLOAK_DB_ENDPOINT}:${process.env.KEYCLOAK_DB_PORT}/${process.env.KEYCLOAK_DB_DATABASE}`
 
-const clientOptions = {
-  ssl: { rejectUnauthorized: false }
-}
+// Only enable SSL if not connecting to localhost
+const isLocal =
+  process.env.POSTGRES_ENDPOINT === "localhost" ||
+  process.env.POSTGRES_ENDPOINT === "127.0.0.1"
+const clientOptions = isLocal
+  ? {}
+  : {
+      ssl: { rejectUnauthorized: false },
+    }
 
 export const client = postgres(connectionString, clientOptions)
 const keycloakClient = postgres(keycloakDBConnectionString, clientOptions)


### PR DESCRIPTION
Local stack is broken after the ssl update in the latest version. This PR fixes this by check the postgres endpoint.