### PR TITLE
Store web scraping parameters

### DIFF
--- a/src/db/migrations/add_scrape_metadata_table.sql
+++ b/src/db/migrations/add_scrape_metadata_table.sql
@@ -1,7 +1,12 @@
-CREATE TABLE "scraping_metadata" (
+CREATE TABLE "scraping_metadata_run" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"course_name" text,
 	"url" text,
 	"max_urls" int,
 	"scrape_strategy" text
+);
+
+CREATE TABLE "scraping_metadata_document" (
+	"run_id" uuid REFERENCES scraping_metadata_run (id) ON DELETE CASCADE,
+	"content" text
 );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -447,12 +447,17 @@ export const keycloakUsers = pgTable('user_entity', {
   not_before: integer('not_before').notNull().default(0),
 })
 
-export const scrapeMetadata = pgTable('scraping_metadata', {
+export const scrapeMetadataRun = pgTable('scraping_metadata_run', {
   id: uuid('id').primaryKey(),
   course_name: text('course_name'),
   url: text('url'),
   max_urls: integer('max_urls').default(50),
   scrape_strategy: text('scrape_strategy').default('Equal and Below'),
+})
+
+export const scrapeMetadataDocument = pgTable('scraping_metadata_document', {
+  run_id: uuid('run_id').references(() => scrapeMetadataRun.id),
+  content: text('content'),
 })
 
 // Table relationships

--- a/src/pages/api/scrapeWeb.ts
+++ b/src/pages/api/scrapeWeb.ts
@@ -1,7 +1,7 @@
 import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import axios from 'axios'
-import { scrapeMetadata, db, messages } from '~/db/dbClient'
+import { scrapeMetadataRun, db, messages } from '~/db/dbClient'
 import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -65,12 +65,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
       scrape_strategy: scrapeStrategy,
     }
     const result = await db
-      .insert(scrapeMetadata)
+      .insert(scrapeMetadataRun)
       .values(storageParams)
       .onConflictDoUpdate({
-        target: scrapeMetadata.id,
+        target: scrapeMetadataRun.id,
         set: storageParams,
       })
+      .returning()
 
     const fullUrl = formatUrl(url)
     const postParams = {
@@ -80,6 +81,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
       scrapeStrategy: scrapeStrategy,
       match: formatUrlAndMatchRegex(fullUrl).matchRegex,
       maxTokens: 2000000,
+      scrapeId: result && result[0] ? result[0].id : null,
     }
 
     const crawleeApiUrl = process.env.CRAWLEE_API_URL


### PR DESCRIPTION
Creates a new "scraping_metadata" table to store a handful of data about the scrape.

This only stores them, it doesn't retrieve or use them on a rescrape yet.