### PR TITLE
fix: use server-side KEYCLOAK_URL for Docker JWT verification

### DIFF
--- a/src/utils/appRouterAuth.ts
+++ b/src/utils/appRouterAuth.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import { type AuthenticatedUser } from '~/middleware'
 import { type NextRequest, NextResponse } from 'next/server'
-import { getKeycloakBaseFromHost } from '~/utils/authHelpers'
+import { getKeycloakBaseFromHost, getKeycloakIssuerBaseUrl } from '~/utils/authHelpers'
 import { verifyTokenAsync } from './keycloakClient'
 
 function getTokenFromCookies(req: NextRequest): string | null {
@@ -47,11 +47,13 @@ export function withAppRouterAuth(
       // Fallback to 'localhost' if undefined
       const hostname = (hostValue ?? 'localhost').split(':')[0]
       const keycloakBaseUrl = getKeycloakBaseFromHost(hostname)
+      const issuerBaseUrl = getKeycloakIssuerBaseUrl(hostname)
 
       // Verify JWT token using Keycloak's JWKS endpoint
       const decoded = (await verifyTokenAsync(
         token,
         keycloakBaseUrl,
+        issuerBaseUrl,
       )) as AuthenticatedUser
 
       // Add user to request object

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -38,13 +38,27 @@ export const getKeycloakBaseUrl = () => {
   return `${window.location.origin}/keycloak/`
 }
 
-// backend
+// backend - used for network requests (JWKS key fetching)
 export function getKeycloakBaseFromHost(hostname: string | undefined): string {
   // Server-side: prefer KEYCLOAK_URL for container-to-container communication
   if (typeof window === 'undefined' && process.env.KEYCLOAK_URL) {
     return process.env.KEYCLOAK_URL
   }
 
+  if (
+    process.env.NEXT_PUBLIC_KEYCLOAK_URL &&
+    process.env.NEXT_PUBLIC_KEYCLOAK_URL.trim() !== ''
+  ) {
+    return process.env.NEXT_PUBLIC_KEYCLOAK_URL
+  }
+  if (hostname === 'localhost') return 'http://localhost:8080/'
+  if (hostname === 'uiuc.chat') return 'https://login.uiuc.chat/'
+  return `https://${hostname}/keycloak/`
+}
+
+// Returns the public-facing Keycloak URL that matches the issuer claim in JWTs.
+// This must match Keycloak's --hostname setting, NOT the internal Docker URL.
+export function getKeycloakIssuerBaseUrl(hostname: string | undefined): string {
   if (
     process.env.NEXT_PUBLIC_KEYCLOAK_URL &&
     process.env.NEXT_PUBLIC_KEYCLOAK_URL.trim() !== ''

--- a/src/utils/authMiddleware.ts
+++ b/src/utils/authMiddleware.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { verifyTokenAsync } from './keycloakClient'
-import { getKeycloakBaseFromHost } from '~/utils/authHelpers'
+import { getKeycloakBaseFromHost, getKeycloakIssuerBaseUrl } from '~/utils/authHelpers'
 import { AuthenticatedUser } from '~/middleware'
 
 function getTokenFromCookies(req: NextApiRequest): string | null {
@@ -36,11 +36,13 @@ export function withAuth(
       // Fallback to 'localhost' if undefined
       const hostname = (hostValue ?? 'localhost').split(':')[0]
       const keycloakBaseUrl = getKeycloakBaseFromHost(hostname)
+      const issuerBaseUrl = getKeycloakIssuerBaseUrl(hostname)
 
       // Verify JWT token using Keycloak's JWKS endpoint
       const decoded = (await verifyTokenAsync(
         token,
         keycloakBaseUrl,
+        issuerBaseUrl,
       )) as AuthenticatedUser
 
       // Add user to request object


### PR DESCRIPTION
## Summary
- Server-side middleware was using `NEXT_PUBLIC_KEYCLOAK_URL` (`http://localhost:8080`) for JWT verification, which resolves to the frontend container itself in Docker — causing `ECONNREFUSED`
- `getKeycloakBaseFromHost()` now checks the runtime `KEYCLOAK_URL` env var first when running server-side, enabling proper container-to-container communication via Docker DNS (`http://keycloak:8080`)
- Separated JWKS key fetching URL (internal `KEYCLOAK_URL`) from JWT issuer verification URL (public-facing, matching Keycloak's `--hostname` setting) to fix `jwt issuer invalid` errors
- Added `getKeycloakIssuerBaseUrl()` helper and updated `createTokenVerifier` / `verifyTokenAsync` to accept a separate issuer URL
- Client-side behavior is unchanged — browsers still use the build-time `NEXT_PUBLIC_KEYCLOAK_URL`

## Test plan
- [ ] Rebuild frontend container (`docker compose build frontend`)
- [ ] Verify JWT verification succeeds (no more `ECONNREFUSED` or `jwt issuer invalid` in middleware logs)
- [ ] Verify browser-side Keycloak login still redirects correctly