### PR TITLE
Failing tests resolution

### DIFF
--- a/src/components/Chat/__tests__/Chat.coverage.test.tsx
+++ b/src/components/Chat/__tests__/Chat.coverage.test.tsx
@@ -271,7 +271,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ banner_image_s3: 'cs101/banner.png' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -311,7 +311,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{} as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -352,7 +352,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{} as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -410,7 +410,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -453,7 +453,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -497,7 +497,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -542,7 +542,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -603,7 +603,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -675,7 +675,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -735,7 +735,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -810,7 +810,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -860,7 +860,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -905,7 +905,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -974,7 +974,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -1023,7 +1023,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{} as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -1091,7 +1091,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -1153,7 +1153,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -1208,7 +1208,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -1262,7 +1262,7 @@ describe('Chat (coverage)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {

--- a/src/components/Chat/__tests__/Chat.queryRewrite.test.tsx
+++ b/src/components/Chat/__tests__/Chat.queryRewrite.test.tsx
@@ -228,7 +228,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -301,7 +301,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -369,7 +369,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -443,7 +443,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -517,7 +517,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -626,7 +626,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -701,7 +701,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -770,7 +770,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -844,7 +844,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {
@@ -918,7 +918,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -985,7 +985,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {
@@ -1055,7 +1055,7 @@ describe('Chat (query rewrite + tool paths)', () => {
         courseMetadata={{ openai_api_key: 'k' } as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={5}
+        documentExists={true}
       />,
       {
         homeState: {

--- a/src/components/Chat/__tests__/Chat.test.tsx
+++ b/src/components/Chat/__tests__/Chat.test.tsx
@@ -155,7 +155,7 @@ describe('Chat', () => {
         courseMetadata={{} as any}
         courseName="CS101"
         currentEmail="me@example.com"
-        documentCount={0}
+        documentExists={false}
       />,
       {
         homeState: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update Chat component tests to use the `documentExists` prop, fixing failures caused by an outdated prop contract.

The `Chat` component was updated to use `documentExists` instead of `documentCount`. Several tests were still passing the old `documentCount` prop, which resulted in `documentExists` being undefined and the query-rewrite/context-retrieval logic being skipped. This PR updates all affected Chat test fixtures to correctly pass `documentExists`.

---
<p><a href="https://cursor.com/agents/bc-4693816a-977b-445a-8541-55c3de290f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4693816a-977b-445a-8541-55c3de290f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->