### PR TITLE
feat: add user last access timestamp per project (#596)

### DIFF
--- a/src/hooks/queries/useFetchCourseMetadata.ts
+++ b/src/hooks/queries/useFetchCourseMetadata.ts
@@ -10,9 +10,14 @@ interface UseFetchCourseMetadataOptions extends FetchCourseMetadataVariables {
   enabled?: boolean
 }
 
+interface CourseMetadataResponse {
+  courseMetadata: CourseMetadata
+  lastAccessedAt: string | null
+}
+
 async function fetchCourseMetadata({
   courseName,
-}: FetchCourseMetadataVariables): Promise<CourseMetadata> {
+}: FetchCourseMetadataVariables): Promise<CourseMetadataResponse> {
   const endpoint = `${getBaseUrl()}/api/UIUC-api/getCourseMetadata?course_name=${courseName}`
   const response = await fetch(endpoint)
 
@@ -38,17 +43,27 @@ async function fetchCourseMetadata({
       data.course_metadata.is_private.toLowerCase() === 'true'
   }
 
-  return data.course_metadata as CourseMetadata
+  return {
+    courseMetadata: data.course_metadata as CourseMetadata,
+    lastAccessedAt: data.last_accessed_at ?? null,
+  }
 }
 
 export function useFetchCourseMetadata({
   courseName,
   enabled = true,
 }: UseFetchCourseMetadataOptions) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ['courseMetadata', courseName],
     queryFn: () => fetchCourseMetadata({ courseName }),
     retry: 1,
     enabled: enabled && Boolean(courseName),
   })
+
+  return {
+    ...query,
+    // Preserve backward compatibility: `data` returns CourseMetadata directly
+    data: query.data?.courseMetadata,
+    lastAccessedAt: query.data?.lastAccessedAt ?? null,
+  }
 }

--- a/src/hooks/queries/useFetchUserLastAccess.ts
+++ b/src/hooks/queries/useFetchUserLastAccess.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+import { getBaseUrl } from '~/utils/apiUtils'
+
+interface UserLastAccessResponse {
+  last_accessed_at: string | null
+}
+
+interface UseFetchUserLastAccessOptions {
+  courseName: string
+  enabled?: boolean
+}
+
+async function fetchUserLastAccess(
+  courseName: string,
+): Promise<string | null> {
+  const endpoint = `${getBaseUrl()}/api/UIUC-api/getUserLastAccess?course_name=${encodeURIComponent(courseName)}`
+  const response = await fetch(endpoint)
+
+  if (!response.ok) {
+    throw new Error(
+      `Error fetching user last access: ${response.statusText || response.status}`,
+    )
+  }
+
+  const data: UserLastAccessResponse = await response.json()
+  return data.last_accessed_at
+}
+
+export function useFetchUserLastAccess({
+  courseName,
+  enabled = true,
+}: UseFetchUserLastAccessOptions) {
+  return useQuery({
+    queryKey: ['userLastAccess', courseName],
+    queryFn: () => fetchUserLastAccess(courseName),
+    retry: 1,
+    enabled: enabled && Boolean(courseName),
+  })
+}

--- a/src/pages/api/UIUC-api/getAllCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getAllCourseMetadata.ts
@@ -3,10 +3,17 @@ import { type NextApiResponse } from 'next'
 import { withAuth, type AuthenticatedRequest } from '~/utils/authMiddleware'
 import type { CourseMetadata } from '~/types/courseMetadata'
 import { ensureRedisConnected } from '~/utils/redisClient'
+import { db } from '~/db/dbClient'
+import { conversations } from '~/db/schema'
+import { eq, max } from 'drizzle-orm'
+
+export type CourseMetadataWithLastAccess = CourseMetadata & {
+  last_accessed_at?: string | null
+}
 
 export const getCoursesByOwnerOrAdmin = async (
   currUserEmail: string,
-): Promise<{ [key: string]: CourseMetadata }[]> => {
+): Promise<{ [key: string]: CourseMetadataWithLastAccess }[]> => {
   let all_course_metadata_raw: { [key: string]: string } | null = null
   try {
     const redisClient = await ensureRedisConnected()
@@ -39,8 +46,43 @@ export const getCoursesByOwnerOrAdmin = async (
         }
         return acc
       },
-      [] as { [key: string]: CourseMetadata }[],
+      [] as { [key: string]: CourseMetadataWithLastAccess }[],
     )
+
+    // Batch-fetch last access timestamps for the current user
+    try {
+      const lastAccessRows = await db
+        .select({
+          projectName: conversations.project_name,
+          lastAccessedAt: max(conversations.updated_at),
+        })
+        .from(conversations)
+        .where(eq(conversations.user_email, currUserEmail))
+        .groupBy(conversations.project_name)
+
+      const lastAccessMap = new Map(
+        lastAccessRows.map((row) => [
+          row.projectName,
+          row.lastAccessedAt?.toISOString() ?? null,
+        ]),
+      )
+
+      for (const entry of course_metadatas) {
+        const courseName = Object.keys(entry)[0]
+        if (courseName) {
+          const metadata = entry[courseName]
+          if (metadata) {
+            entry[courseName] = {
+              ...metadata,
+              last_accessed_at: lastAccessMap.get(courseName) ?? null,
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching last access timestamps:', error)
+      // Non-fatal: return metadata without last_accessed_at
+    }
 
     return course_metadatas
   } catch (error) {

--- a/src/pages/api/UIUC-api/getCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getCourseMetadata.ts
@@ -4,6 +4,9 @@ import { withCourseAccessFromRequest } from '~/pages/api/authorization'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { ensureRedisConnected } from '~/utils/redisClient'
+import { db } from '~/db/dbClient'
+import { conversations } from '~/db/schema'
+import { and, eq, max } from 'drizzle-orm'
 
 export const getCourseMetadata = async (
   course_name: string,
@@ -23,6 +26,28 @@ export const getCourseMetadata = async (
   }
 }
 
+export const getUserLastAccessForCourse = async (
+  userEmail: string,
+  courseName: string,
+): Promise<string | null> => {
+  try {
+    const result = await db
+      .select({ lastAccessedAt: max(conversations.updated_at) })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.user_email, userEmail),
+          eq(conversations.project_name, courseName),
+        ),
+      )
+
+    return result[0]?.lastAccessedAt?.toISOString() ?? null
+  } catch (error) {
+    console.error('Error fetching user last access:', error)
+    return null
+  }
+}
+
 export default withCourseAccessFromRequest('any')(handler)
 
 async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
@@ -35,7 +60,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         .status(404)
         .json({ success: false, error: 'Project not found' })
     }
-    res.status(200).json({ course_metadata: course_metadata })
+
+    const userEmail = req.user?.email
+    const last_accessed_at = userEmail
+      ? await getUserLastAccessForCourse(userEmail, course_name)
+      : null
+
+    res.status(200).json({ course_metadata: course_metadata, last_accessed_at })
   } catch (error) {
     console.log('Error occurred while fetching courseMetadata', error)
     res.status(500).json({ success: false, error: error })

--- a/src/pages/api/UIUC-api/getUserLastAccess.ts
+++ b/src/pages/api/UIUC-api/getUserLastAccess.ts
@@ -1,0 +1,38 @@
+import { type NextApiResponse } from 'next'
+import { withAuth, type AuthenticatedRequest } from '~/utils/authMiddleware'
+import { getUserLastAccessForCourse } from '~/pages/api/UIUC-api/getCourseMetadata'
+
+async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const courseName = req.query.course_name as string | undefined
+
+  if (!courseName) {
+    return res
+      .status(400)
+      .json({ error: 'Missing required course_name parameter' })
+  }
+
+  const userEmail = req.user?.email
+  if (!userEmail) {
+    return res.status(401).json({ error: 'User email not found in token' })
+  }
+
+  try {
+    const lastAccessedAt = await getUserLastAccessForCourse(
+      userEmail,
+      courseName,
+    )
+
+    return res.status(200).json({
+      last_accessed_at: lastAccessedAt,
+    })
+  } catch (error) {
+    console.error('Error fetching user last access:', error)
+    return res.status(500).json({ error: 'Failed to fetch user last access' })
+  }
+}
+
+export default withAuth(handler)


### PR DESCRIPTION
Add getUserLastAccess API endpoint and embed last_accessed_at in getCourseMetadata and getAllCourseMetadata responses to reduce request count. Derives timestamp from MAX(conversations.updated_at).