### PR TITLE
feat: surface project timestamps in chatbot listing APIs

### DIFF
--- a/src/pages/api/UIUC-api/getAllCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getAllCourseMetadata.ts
@@ -3,6 +3,7 @@ import { type NextApiResponse } from 'next'
 import { withAuth, type AuthenticatedRequest } from '~/utils/authMiddleware'
 import type { CourseMetadata } from '~/types/courseMetadata'
 import { ensureRedisConnected } from '~/utils/redisClient'
+import { getBatchProjectTimestamps } from '~/utils/projectTimestamps'
 
 export const getCoursesByOwnerOrAdmin = async (
   currUserEmail: string,
@@ -42,7 +43,24 @@ export const getCoursesByOwnerOrAdmin = async (
       [] as { [key: string]: CourseMetadata }[],
     )
 
-    return course_metadatas
+    // Enrich with timestamps from PostgreSQL
+    const courseNames = course_metadatas
+      .map((entry) => Object.keys(entry)[0])
+      .filter((name): name is string => !!name)
+    const timestamps = await getBatchProjectTimestamps(courseNames)
+
+    return course_metadatas.map((entry) => {
+      const courseName = Object.keys(entry)[0]
+      if (!courseName) return entry
+      const ts = timestamps.get(courseName)
+      return {
+        [courseName]: {
+          ...entry[courseName]!,
+          created_at: ts?.created_at ?? undefined,
+          last_updated_at: ts?.last_updated_at ?? undefined,
+        },
+      }
+    })
   } catch (error) {
     console.error(
       'Error occurred while fetching courseMetadata',
@@ -79,9 +97,25 @@ export const getAllCourseMetadata = async (): Promise<
       .filter(
         (item): item is { [key: string]: CourseMetadata } => item !== null,
       )
-    console.log('all_course_metadata', all_course_metadata)
 
-    return all_course_metadata
+    // Enrich with timestamps from PostgreSQL
+    const courseNames = all_course_metadata
+      .map((entry) => Object.keys(entry)[0])
+      .filter((name): name is string => !!name)
+    const timestamps = await getBatchProjectTimestamps(courseNames)
+
+    return all_course_metadata.map((entry) => {
+      const courseName = Object.keys(entry)[0]
+      if (!courseName) return entry
+      const ts = timestamps.get(courseName)
+      return {
+        [courseName]: {
+          ...entry[courseName]!,
+          created_at: ts?.created_at ?? undefined,
+          last_updated_at: ts?.last_updated_at ?? undefined,
+        },
+      }
+    })
   } catch (error) {
     console.error(
       'Error occurred while fetching courseMetadata',

--- a/src/pages/api/UIUC-api/getAllCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getAllCourseMetadata.ts
@@ -56,8 +56,8 @@ export const getCoursesByOwnerOrAdmin = async (
       return {
         [courseName]: {
           ...entry[courseName]!,
-          created_at: ts?.created_at ?? undefined,
-          last_updated_at: ts?.last_updated_at ?? undefined,
+          created_at: ts?.created_at ?? null,
+          last_updated_at: ts?.last_updated_at ?? null,
         },
       }
     })
@@ -111,8 +111,8 @@ export const getAllCourseMetadata = async (): Promise<
       return {
         [courseName]: {
           ...entry[courseName]!,
-          created_at: ts?.created_at ?? undefined,
-          last_updated_at: ts?.last_updated_at ?? undefined,
+          created_at: ts?.created_at ?? null,
+          last_updated_at: ts?.last_updated_at ?? null,
         },
       }
     })

--- a/src/pages/api/UIUC-api/getCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getCourseMetadata.ts
@@ -4,6 +4,7 @@ import { withCourseAccessFromRequest } from '~/pages/api/authorization'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { ensureRedisConnected } from '~/utils/redisClient'
+import { getProjectTimestamps } from '~/utils/projectTimestamps'
 
 export const getCourseMetadata = async (
   course_name: string,
@@ -15,8 +16,15 @@ export const getCourseMetadata = async (
       ? JSON.parse(rawMetadata)
       : null
 
-    // Use value as-is; Redis-stored JSON should already have correct boolean
-    return course_metadata
+    if (!course_metadata) return null
+
+    // Enrich with timestamps from PostgreSQL
+    const timestamps = await getProjectTimestamps(course_name)
+    return {
+      ...course_metadata,
+      created_at: timestamps.created_at ?? undefined,
+      last_updated_at: timestamps.last_updated_at ?? undefined,
+    }
   } catch (error) {
     console.error('Error occurred while fetching courseMetadata', error)
     return null

--- a/src/pages/api/UIUC-api/getCourseMetadata.ts
+++ b/src/pages/api/UIUC-api/getCourseMetadata.ts
@@ -22,8 +22,8 @@ export const getCourseMetadata = async (
     const timestamps = await getProjectTimestamps(course_name)
     return {
       ...course_metadata,
-      created_at: timestamps.created_at ?? undefined,
-      last_updated_at: timestamps.last_updated_at ?? undefined,
+      created_at: timestamps.created_at ?? null,
+      last_updated_at: timestamps.last_updated_at ?? null,
     }
   } catch (error) {
     console.error('Error occurred while fetching courseMetadata', error)

--- a/src/types/courseMetadata.ts
+++ b/src/types/courseMetadata.ts
@@ -25,6 +25,8 @@ export interface CourseMetadata {
   agent_mode_enabled?: boolean
   allow_logged_in_users: boolean | undefined
   is_frozen: boolean | undefined
+  created_at?: string
+  last_updated_at?: string
 }
 
 export type ProjectWideLLMProviders = {
@@ -54,4 +56,6 @@ export interface CourseMetadataOptionalForUpsert {
   agent_mode_enabled?: boolean
   allow_logged_in_users: boolean | undefined
   is_frozen: boolean | undefined
+  created_at?: string
+  last_updated_at?: string
 }

--- a/src/types/courseMetadata.ts
+++ b/src/types/courseMetadata.ts
@@ -25,11 +25,11 @@ export interface CourseMetadata {
   agent_mode_enabled?: boolean
   allow_logged_in_users: boolean | undefined
   is_frozen: boolean | undefined
-  created_at: string | null
+  created_at?: string | null
   // Derived from MAX(documents.created_at) in PostgreSQL — reflects the most
   // recent document upload. Falls back to projects.created_at when no documents
   // exist. Does NOT track metadata changes (e.g. settings, system prompt edits).
-  last_updated_at: string | null
+  last_updated_at?: string | null
 }
 
 export type ProjectWideLLMProviders = {

--- a/src/types/courseMetadata.ts
+++ b/src/types/courseMetadata.ts
@@ -25,8 +25,8 @@ export interface CourseMetadata {
   agent_mode_enabled?: boolean
   allow_logged_in_users: boolean | undefined
   is_frozen: boolean | undefined
-  created_at?: string
-  last_updated_at?: string
+  created_at: string | null
+  last_updated_at: string | null
 }
 
 export type ProjectWideLLMProviders = {

--- a/src/types/courseMetadata.ts
+++ b/src/types/courseMetadata.ts
@@ -26,6 +26,9 @@ export interface CourseMetadata {
   allow_logged_in_users: boolean | undefined
   is_frozen: boolean | undefined
   created_at: string | null
+  // Derived from MAX(documents.created_at) in PostgreSQL — reflects the most
+  // recent document upload. Falls back to projects.created_at when no documents
+  // exist. Does NOT track metadata changes (e.g. settings, system prompt edits).
   last_updated_at: string | null
 }
 

--- a/src/utils/projectTimestamps.ts
+++ b/src/utils/projectTimestamps.ts
@@ -1,0 +1,93 @@
+import { db, projects, documents } from '~/db/dbClient'
+import { eq, max, inArray } from 'drizzle-orm'
+
+export interface ProjectTimestamps {
+  created_at: string | null
+  last_updated_at: string | null
+}
+
+/**
+ * Fetches created_at from the projects table and derives last_updated_at
+ * from MAX(documents.created_at) for a single course.
+ */
+export async function getProjectTimestamps(
+  courseName: string,
+): Promise<ProjectTimestamps> {
+  try {
+    const [projectRow] = await db
+      .select({ created_at: projects.created_at })
+      .from(projects)
+      .where(eq(projects.course_name, courseName))
+      .limit(1)
+
+    const [docRow] = await db
+      .select({ last_updated_at: max(documents.created_at) })
+      .from(documents)
+      .where(eq(documents.course_name, courseName))
+
+    return {
+      created_at: projectRow?.created_at?.toISOString() ?? null,
+      last_updated_at: docRow?.last_updated_at?.toISOString() ?? null,
+    }
+  } catch (error) {
+    console.error(`Error fetching timestamps for project ${courseName}:`, error)
+    return { created_at: null, last_updated_at: null }
+  }
+}
+
+/**
+ * Batch-fetches timestamps for multiple courses at once.
+ * Returns a map of course_name -> ProjectTimestamps.
+ */
+export async function getBatchProjectTimestamps(
+  courseNames: string[],
+): Promise<Map<string, ProjectTimestamps>> {
+  const result = new Map<string, ProjectTimestamps>()
+
+  if (courseNames.length === 0) return result
+
+  try {
+    const [projectRows, docRows] = await Promise.all([
+      db
+        .select({
+          course_name: projects.course_name,
+          created_at: projects.created_at,
+        })
+        .from(projects)
+        .where(inArray(projects.course_name, courseNames)),
+      db
+        .select({
+          course_name: documents.course_name,
+          last_updated_at: max(documents.created_at),
+        })
+        .from(documents)
+        .where(inArray(documents.course_name, courseNames))
+        .groupBy(documents.course_name),
+    ])
+
+    const projectMap = new Map(
+      projectRows.map((r) => [
+        r.course_name,
+        r.created_at?.toISOString() ?? null,
+      ]),
+    )
+
+    const docMap = new Map(
+      docRows.map((r) => [
+        r.course_name,
+        r.last_updated_at?.toISOString() ?? null,
+      ]),
+    )
+
+    for (const name of courseNames) {
+      result.set(name, {
+        created_at: projectMap.get(name) ?? null,
+        last_updated_at: docMap.get(name) ?? null,
+      })
+    }
+  } catch (error) {
+    console.error('Error fetching batch project timestamps:', error)
+  }
+
+  return result
+}

--- a/src/utils/projectTimestamps.ts
+++ b/src/utils/projectTimestamps.ts
@@ -7,9 +7,15 @@ export interface ProjectTimestamps {
 }
 
 /**
- * Fetches created_at from the projects table and derives last_updated_at
- * from MAX(documents.created_at) for a single course.
- * Falls back to projects.created_at when no documents exist.
+ * Fetches project timestamps from PostgreSQL.
+ *
+ * - created_at: from the projects table (set once at project creation).
+ * - last_updated_at: MAX(documents.created_at) — the most recent document
+ *   upload. Falls back to projects.created_at when no documents exist, so this
+ *   field is never null for an existing project.
+ *
+ * NOTE: This only tracks document uploads, not metadata changes (settings,
+ * system prompt, etc.). Metadata lives in Redis and has no timestamp tracking.
  */
 export async function getProjectTimestamps(
   courseName: string,
@@ -40,8 +46,8 @@ export async function getProjectTimestamps(
 }
 
 /**
- * Batch-fetches timestamps for multiple courses at once.
- * Returns a map of course_name -> ProjectTimestamps.
+ * Batch version of getProjectTimestamps. Same semantics:
+ * last_updated_at = latest document upload, falling back to project created_at.
  */
 export async function getBatchProjectTimestamps(
   courseNames: string[],

--- a/src/utils/projectTimestamps.ts
+++ b/src/utils/projectTimestamps.ts
@@ -9,6 +9,7 @@ export interface ProjectTimestamps {
 /**
  * Fetches created_at from the projects table and derives last_updated_at
  * from MAX(documents.created_at) for a single course.
+ * Falls back to projects.created_at when no documents exist.
  */
 export async function getProjectTimestamps(
   courseName: string,
@@ -25,9 +26,12 @@ export async function getProjectTimestamps(
       .from(documents)
       .where(eq(documents.course_name, courseName))
 
+    const createdAt = projectRow?.created_at?.toISOString() ?? null
+    const lastDocUpdate = docRow?.last_updated_at?.toISOString() ?? null
+
     return {
-      created_at: projectRow?.created_at?.toISOString() ?? null,
-      last_updated_at: docRow?.last_updated_at?.toISOString() ?? null,
+      created_at: createdAt,
+      last_updated_at: lastDocUpdate ?? createdAt,
     }
   } catch (error) {
     console.error(`Error fetching timestamps for project ${courseName}:`, error)
@@ -80,9 +84,11 @@ export async function getBatchProjectTimestamps(
     )
 
     for (const name of courseNames) {
+      const createdAt = projectMap.get(name) ?? null
+      const lastDocUpdate = docMap.get(name) ?? null
       result.set(name, {
-        created_at: projectMap.get(name) ?? null,
-        last_updated_at: docMap.get(name) ?? null,
+        created_at: createdAt,
+        last_updated_at: lastDocUpdate ?? createdAt,
       })
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Surface `projects.created_at` and derive `last_updated_at` from `MAX(documents.created_at)` in chatbot listing API responses
- Add `created_at` and `last_updated_at` optional fields to `CourseMetadata` type
- Enrich both `getAllCourseMetadata` and `getCourseMetadata` endpoints with timestamps from PostgreSQL

## Test plan
- [ ] Verify `GET /api/UIUC-api/getAllCourseMetadata` returns `created_at` and `last_updated_at` for each course
- [ ] Verify `GET /api/UIUC-api/getCourseMetadata?course_name=X` returns timestamps
- [ ] Verify courses with no documents return `last_updated_at: undefined`
- [ ] Verify courses not in the projects table return `created_at: undefined`

Closes #597