### PR TITLE
fix: surface subdomain crawl progress in ingest toast (#644)

### DIFF
--- a/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -191,6 +191,24 @@ export default function WebsiteIngestForm({
         `/api/materialsTable/successDocs?course_name=${project_name}`,
       )
       const docsData = await docsResponse.json()
+
+      // Strip trailing slashes so the user-entered URL and the backend-stored
+      // base_url compare equal even when one has a trailing slash and the
+      // other doesn't.
+      const normalizeUrl = (url: string | undefined | null) =>
+        (url ?? '').replace(/\/+$/, '')
+
+      const baseUrlMatchesFile = (
+        docBaseUrl: string,
+        file: FileUpload,
+      ): boolean => {
+        const normBase = normalizeUrl(docBaseUrl)
+        return (
+          normalizeUrl(file.name) === normBase ||
+          normalizeUrl(file.url) === normBase
+        )
+      }
+
       // Helper function to organize docs by base URL
       const organizeDocsByBaseUrl = (
         docs: Array<{ base_url: string; url: string }>,
@@ -198,10 +216,11 @@ export default function WebsiteIngestForm({
         const baseUrlMap = new Map<string, Set<string>>()
 
         docs.forEach((doc) => {
-          if (!baseUrlMap.has(doc.base_url)) {
-            baseUrlMap.set(doc.base_url, new Set())
+          const key = normalizeUrl(doc.base_url)
+          if (!baseUrlMap.has(key)) {
+            baseUrlMap.set(key, new Set())
           }
-          baseUrlMap.get(doc.base_url)?.add(doc.url)
+          baseUrlMap.get(key)?.add(doc.url)
         })
 
         return baseUrlMap
@@ -216,10 +235,8 @@ export default function WebsiteIngestForm({
           if (file.type !== 'webscrape') return file
           const fileUrl = file.url ?? ''
 
-          const isStillIngesting = docsInProgress.some(
-            (doc) =>
-              doc.base_url === file.name ||
-              (file.isBaseUrl && doc.base_url === file.url),
+          const isStillIngesting = docsInProgress.some((doc) =>
+            baseUrlMatchesFile(doc.base_url, file),
           )
 
           if (file.status === 'uploading' && isStillIngesting) {
@@ -238,8 +255,9 @@ export default function WebsiteIngestForm({
 
               const isInCompletedDocs = docsData?.documents?.some(
                 (doc: { url: string; base_url?: string }) =>
-                  doc.url === file.url ||
-                  (file.isBaseUrl && doc.base_url === file.url),
+                  normalizeUrl(doc.url) === normalizeUrl(file.url) ||
+                  (file.isBaseUrl &&
+                    normalizeUrl(doc.base_url) === normalizeUrl(file.url)),
               )
 
               if (file.isBaseUrl && allChildrenDone && isInCompletedDocs) {
@@ -258,37 +276,54 @@ export default function WebsiteIngestForm({
         })
       }
 
-      // Helper function to create new file entries for additional URLs
+      // Helper function to create new file entries for additional URLs.
+      // Includes both in-progress and already-completed docs so that URLs
+      // which finished crawling between polls still show up in the toast.
       const createAdditionalFileEntries = (
-        baseUrlMap: Map<string, Set<string>>,
+        inProgressBaseUrlMap: Map<string, Set<string>>,
+        successBaseUrlMap: Map<string, Set<string>>,
         currentFiles: FileUpload[],
-        docsInProgress: Array<{ base_url: string; readable_filename: string }>,
       ) => {
         const newFiles: FileUpload[] = []
+        const seenUrls = new Set<string>()
 
-        baseUrlMap.forEach((urls, baseUrl) => {
-          // Only process if we have this base URL in our current files
-          if (currentFiles.some((file) => file.name === baseUrl)) {
-            const matchingDoc = docsInProgress.find(
-              (doc) => doc.base_url === baseUrl,
-            )
+        const hasMatchingBaseUrl = (baseUrl: string) =>
+          currentFiles.some((file) => baseUrlMatchesFile(baseUrl, file))
 
-            const isStillIngesting = matchingDoc !== undefined
+        const alreadyTracked = (url: string) =>
+          seenUrls.has(url) ||
+          currentFiles.some(
+            (file) =>
+              normalizeUrl(file.url) === normalizeUrl(url) ||
+              normalizeUrl(file.name) === normalizeUrl(url),
+          )
 
-            urls.forEach((url) => {
-              if (
-                !currentFiles.some((file) => file.url === url) &&
-                matchingDoc
-              ) {
-                newFiles.push({
-                  name: url,
-                  status: isStillIngesting ? 'ingesting' : 'complete',
-                  type: 'webscrape',
-                  url: url,
-                })
-              }
+        inProgressBaseUrlMap.forEach((urls, baseUrl) => {
+          if (!hasMatchingBaseUrl(baseUrl)) return
+          urls.forEach((url) => {
+            if (alreadyTracked(url)) return
+            seenUrls.add(url)
+            newFiles.push({
+              name: url,
+              status: 'ingesting',
+              type: 'webscrape',
+              url: url,
             })
-          }
+          })
+        })
+
+        successBaseUrlMap.forEach((urls, baseUrl) => {
+          if (!hasMatchingBaseUrl(baseUrl)) return
+          urls.forEach((url) => {
+            if (alreadyTracked(url)) return
+            seenUrls.add(url)
+            newFiles.push({
+              name: url,
+              status: 'complete',
+              type: 'webscrape',
+              url: url,
+            })
+          })
         })
 
         return newFiles
@@ -297,15 +332,23 @@ export default function WebsiteIngestForm({
       setUploadFiles((prev) => {
         const matchingDocsInProgress =
           data?.documents?.filter((doc: { base_url: string }) =>
-            prev.some((file) => file.name === doc.base_url),
+            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
           ) || []
 
-        const baseUrlMap = organizeDocsByBaseUrl(matchingDocsInProgress)
+        const matchingSuccessDocs =
+          docsData?.documents?.filter((doc: { base_url: string }) =>
+            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
+          ) || []
+
+        const inProgressBaseUrlMap = organizeDocsByBaseUrl(
+          matchingDocsInProgress,
+        )
+        const successBaseUrlMap = organizeDocsByBaseUrl(matchingSuccessDocs)
 
         const additionalFiles = createAdditionalFileEntries(
-          baseUrlMap,
+          inProgressBaseUrlMap,
+          successBaseUrlMap,
           prev,
-          matchingDocsInProgress,
         )
 
         const updatedFiles = updateExistingFiles(prev, matchingDocsInProgress)

--- a/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -99,6 +99,114 @@ describe('WebsiteIngestForm', () => {
     })
   })
 
+  it('surfaces already-completed child URLs from successDocs even when docsInProgress is empty', async () => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+      fn()
+      // @ts-expect-error - minimal timer handle for tests
+      return 0
+    })
+
+    server.use(
+      http.get('*/api/materialsTable/docsInProgress*', async () => {
+        return HttpResponse.json({ documents: [] })
+      }),
+      http.get('*/api/materialsTable/successDocs*', async () => {
+        return HttpResponse.json({
+          documents: [
+            {
+              base_url: 'https://example.com',
+              url: 'https://example.com/child1',
+              readable_filename: 'child1',
+            },
+            {
+              base_url: 'https://example.com',
+              url: 'https://example.com/child2',
+              readable_filename: 'child2',
+            },
+          ],
+        })
+      }),
+    )
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            name: 'https://example.com',
+            status: 'ingesting',
+            type: 'webscrape',
+            url: 'https://example.com',
+            isBaseUrl: true,
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    await waitFor(() => {
+      const filesJson = screen.getByTestId('files').textContent ?? ''
+      expect(filesJson).toContain('https://example.com/child1')
+      expect(filesJson).toContain('https://example.com/child2')
+      expect(filesJson).toContain('"status":"complete"')
+    })
+  })
+
+  it('matches docs.base_url to the file URL even when trailing slashes differ', async () => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+      fn()
+      // @ts-expect-error - minimal timer handle for tests
+      return 0
+    })
+
+    server.use(
+      http.get('*/api/materialsTable/docsInProgress*', async () => {
+        return HttpResponse.json({
+          documents: [
+            {
+              // backend strips trailing slash
+              base_url: 'https://example.com',
+              url: 'https://example.com/alpha',
+              readable_filename: 'alpha',
+            },
+          ],
+        })
+      }),
+      http.get('*/api/materialsTable/successDocs*', async () => {
+        return HttpResponse.json({ documents: [] })
+      }),
+    )
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            // user entered URL with trailing slash
+            name: 'https://example.com/',
+            status: 'uploading',
+            type: 'webscrape',
+            url: 'https://example.com/',
+            isBaseUrl: true,
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    await waitFor(() => {
+      const filesJson = screen.getByTestId('files').textContent ?? ''
+      expect(filesJson).toContain('https://example.com/alpha')
+      expect(filesJson).toContain('"status":"ingesting"')
+    })
+  })
+
   it('polls ingest status and marks an ingesting file as complete when it shows up in success docs', async () => {
     vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
       fn()


### PR DESCRIPTION
## Summary
- Closes #644. Subdomain/domain crawls were only surfacing the base URL in the toast because child-URL discovery read exclusively from `docsInProgress` and matched `base_url` with strict string equality. Pages that transitioned through `docsInProgress` between 3-second polls, or whose backend-stored `base_url` differed from the user-entered URL by a trailing slash, were never added to `uploadFiles` and therefore never surfaced in the toast.
- `WebsiteIngestForm.tsx` now normalizes URLs (strips trailing slashes) when comparing `base_url` to the tracked file entry, and `createAdditionalFileEntries` additionally pulls already-completed child URLs from `successDocs` and appends them as `complete`. This works for both the dashboard (`MakeOldCoursePage` / `UploadCard`) and the new chatbot wizard (`MakeNewCoursePage` / `StepUpload`) since they share this component.

## Test plan
- [x] `npx vitest run src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx` — all 7 tests pass, including two new cases:
  - surfaces already-completed child URLs from `successDocs` when `docsInProgress` is empty
  - matches `docs.base_url` to the file URL even when trailing slashes differ
- [ ] Manual verification on `/new` (chatbot wizard): crawl `https://www.ncsa.illinois.edu/` with "Entire domain" — confirm the toast lists more than one URL as pages are crawled
- [ ] Manual verification on `/[course_name]/dashboard`: same scenario — confirm the toast updates with subdomain URLs as they complete