### PR TITLE
183 document group filtering is broken

### DIFF
--- a/__tests__/pages/api/chat-api/__tests__/chat.test.ts
+++ b/__tests__/pages/api/chat-api/__tests__/chat.test.ts
@@ -328,9 +328,9 @@ describe('chat-api/chat', () => {
           api_key: 'k',
           retrieval_only: false,
         },
-        socket: { remoteAddress: '127.0.0.1' } as any,
-      }) as any,
-      res as any,
+        socket: { remoteAddress: '127.0.0.1' } as unknown,
+      }) as Parameters<typeof chat>[0],
+      res as Parameters<typeof chat>[1],
     )
     expect(hoisted.handleStreamingResponse).toHaveBeenCalled()
   })
@@ -350,9 +350,9 @@ describe('chat-api/chat', () => {
           api_key: 'k',
           retrieval_only: false,
         },
-        socket: { remoteAddress: '127.0.0.1' } as any,
-      }) as any,
-      res as any,
+        socket: { remoteAddress: '127.0.0.1' } as unknown,
+      }) as Parameters<typeof chat>[0],
+      res as Parameters<typeof chat>[1],
     )
     expect(hoisted.handleContextSearch).toHaveBeenCalledWith(
       expect.any(Object),

--- a/__tests__/pages/api/chat-api/__tests__/chat.test.ts
+++ b/__tests__/pages/api/chat-api/__tests__/chat.test.ts
@@ -89,9 +89,9 @@ describe('chat-api/chat', () => {
     await chat(
       createMockReq({
         method: 'GET',
-        socket: { remoteAddress: '127.0.0.1' } as any,
-      }) as any,
-      res as any,
+        socket: { remoteAddress: '127.0.0.1' } as unknown,
+      }) as Parameters<typeof chat>[0],
+      res as Parameters<typeof chat>[1],
     )
     expect(res.status).toHaveBeenCalledWith(405)
   })
@@ -151,9 +151,9 @@ describe('chat-api/chat', () => {
           api_key: 'k',
           retrieval_only: false,
         },
-        socket: { remoteAddress: '127.0.0.1' } as any,
-      }) as any,
-      res as any,
+        socket: { remoteAddress: '127.0.0.1' } as unknown,
+      }) as Parameters<typeof chat>[0],
+      res as Parameters<typeof chat>[1],
     )
     expect(res.status).toHaveBeenCalledWith(404)
   })
@@ -379,9 +379,9 @@ describe('chat-api/chat', () => {
           retrieval_only: false,
           doc_groups: ['Group A'],
         },
-        socket: { remoteAddress: '127.0.0.1' } as any,
-      }) as any,
-      res as any,
+        socket: { remoteAddress: '127.0.0.1' } as unknown,
+      }) as Parameters<typeof chat>[0],
+      res as Parameters<typeof chat>[1],
     )
     expect(hoisted.handleContextSearch).toHaveBeenCalledWith(
       expect.any(Object),

--- a/__tests__/pages/api/chat-api/__tests__/chat.test.ts
+++ b/__tests__/pages/api/chat-api/__tests__/chat.test.ts
@@ -335,6 +335,63 @@ describe('chat-api/chat', () => {
     expect(hoisted.handleStreamingResponse).toHaveBeenCalled()
   })
 
+  it('defaults doc_groups to All Documents when not provided', async () => {
+    hoisted.handleContextSearch.mockClear()
+    const res = createMockRes()
+    await chat(
+      createMockReq({
+        method: 'POST',
+        body: {
+          model: 'gpt-4o',
+          messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+          temperature: 0.1,
+          course_name: 'CS101',
+          stream: false,
+          api_key: 'k',
+          retrieval_only: false,
+        },
+        socket: { remoteAddress: '127.0.0.1' } as any,
+      }) as any,
+      res as any,
+    )
+    expect(hoisted.handleContextSearch).toHaveBeenCalledWith(
+      expect.any(Object),
+      'CS101',
+      expect.any(Object),
+      expect.any(String),
+      ['All Documents'],
+    )
+  })
+
+  it('preserves provided doc_groups instead of overriding to All Documents', async () => {
+    hoisted.handleContextSearch.mockClear()
+    const res = createMockRes()
+    await chat(
+      createMockReq({
+        method: 'POST',
+        body: {
+          model: 'gpt-4o',
+          messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+          temperature: 0.1,
+          course_name: 'CS101',
+          stream: false,
+          api_key: 'k',
+          retrieval_only: false,
+          doc_groups: ['Group A'],
+        },
+        socket: { remoteAddress: '127.0.0.1' } as any,
+      }) as any,
+      res as any,
+    )
+    expect(hoisted.handleContextSearch).toHaveBeenCalledWith(
+      expect.any(Object),
+      'CS101',
+      expect.any(Object),
+      expect.any(String),
+      ['Group A'],
+    )
+  })
+
   it('invokes handleImageContent and handleToolsServer when image content and tools are present', async () => {
     hoisted.fetchTools.mockResolvedValueOnce([{ id: 't1' }])
     hoisted.handleContextSearch.mockResolvedValueOnce([{ id: 1 }])

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -239,9 +239,10 @@ export const Chat = memo(
         const documentGroupActions = [
           DEFAULT_DOCUMENT_GROUP,
           ...(documentGroupsHook?.map((docGroup, index) => ({
-            id: `DocGroup-${index}`,
+            id: docGroup.id != null ? String(docGroup.id) : `DocGroup-${index}`,
             name: docGroup.name,
             checked: false,
+            adminDisabled: docGroup.enabled === false,
             onTrigger: () => console.log(`${docGroup.name} triggered`),
           })) || []),
         ]
@@ -256,7 +257,7 @@ export const Chat = memo(
     useEffect(() => {
       setEnabledDocumentGroups(
         documentGroups
-          .filter((action) => action.checked)
+          .filter((action) => action.checked && !action.adminDisabled)
           .map((action) => action.name),
       )
     }, [documentGroups])
@@ -863,7 +864,7 @@ export const Chat = memo(
               courseName,
               selectedConversation,
               rewrittenQuery,
-              enabledDocumentGroups,
+              documentGroups,
             )
 
             homeDispatch({ field: 'isRetrievalLoading', value: false })
@@ -938,7 +939,7 @@ export const Chat = memo(
               abortAgent,
               conversations,
               courseName,
-              enabledDocumentGroups,
+              enabledDocumentGroups: documentGroups,
               errorToast,
               homeDispatch,
               message,

--- a/src/components/Chat/DocumentGroupsItem.tsx
+++ b/src/components/Chat/DocumentGroupsItem.tsx
@@ -49,11 +49,6 @@ export const DocumentGroupsItem = ({}) => {
     })
   }
 
-  const hasAdminDisabledGroups = useMemo(
-    () => documentGroups.some((g) => g.adminDisabled),
-    [documentGroups],
-  )
-
   return (
     <>
       <div

--- a/src/components/Chat/DocumentGroupsItem.tsx
+++ b/src/components/Chat/DocumentGroupsItem.tsx
@@ -1,7 +1,7 @@
-import { Switch, Table, TextInput, Title, Text } from '@mantine/core'
+import { Switch, Table, TextInput, Title, Text, Tooltip } from '@mantine/core'
 import { IconSearch } from '@tabler/icons-react'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import HomeContext from '~/pages/api/home/home.context'
 import { useMediaQuery } from '@mantine/hooks'
 
@@ -35,7 +35,10 @@ export const DocumentGroupsItem = ({}) => {
   }
 
   const handleToggleChecked = (id: string) => {
-    // handleUpdateActions(id)
+    const target = documentGroups.find((docGroup) => docGroup.id === id)
+    if (target?.adminDisabled) {
+      return
+    }
     homeDispatch({
       field: 'documentGroups',
       value: documentGroups.map((docGroup) =>
@@ -46,10 +49,10 @@ export const DocumentGroupsItem = ({}) => {
     })
   }
 
-  // For testing purposes
-  // useEffect(() => {
-  //   console.log('Document groups updated: ', documentGroups)
-  // }, [documentGroups])
+  const hasAdminDisabledGroups = useMemo(
+    () => documentGroups.some((g) => g.adminDisabled),
+    [documentGroups],
+  )
 
   return (
     <>
@@ -133,7 +136,12 @@ export const DocumentGroupsItem = ({}) => {
               </thead>
               <tbody>
                 {filteredDocumentGroups.map((doc_group_obj, index) => (
-                  <tr key={index}>
+                  <tr
+                    key={doc_group_obj.id ?? index}
+                    className={
+                      doc_group_obj.adminDisabled ? 'opacity-[0.72]' : undefined
+                    }
+                  >
                     <td style={{ wordWrap: 'break-word' }}>
                       <Text
                         className={`${
@@ -152,21 +160,43 @@ export const DocumentGroupsItem = ({}) => {
                         wordWrap: 'break-word',
                       }}
                     >
-                      <Switch
-                        checked={doc_group_obj.checked}
-                        onChange={() => handleToggleChecked(doc_group_obj.id)}
-                        className="cursor-pointer"
-                        styles={{
-                          track: {
-                            backgroundColor: doc_group_obj.checked
-                              ? 'var(--dashboard-button) !important'
-                              : 'var(--dashboard-background-dark)',
-                            borderColor: doc_group_obj.checked
-                              ? 'var(--dashboard-button) !important'
-                              : 'var(--dashboard-background-dark)',
-                          },
-                        }}
-                      />
+                      <Tooltip
+                        label="Admin has disabled that doc group"
+                        disabled={!doc_group_obj.adminDisabled}
+                        withinPortal
+                      >
+                        <span
+                          style={{ display: 'inline-flex' }}
+                          className={
+                            doc_group_obj.adminDisabled
+                              ? undefined
+                              : 'cursor-pointer'
+                          }
+                        >
+                          <Switch
+                            checked={doc_group_obj.checked}
+                            disabled={doc_group_obj.adminDisabled}
+                            aria-label={
+                              doc_group_obj.adminDisabled
+                                ? `${doc_group_obj.name}: Admin has disabled that doc group`
+                                : `${doc_group_obj.name}: toggle document group`
+                            }
+                            onChange={() =>
+                              handleToggleChecked(doc_group_obj.id)
+                            }
+                            styles={{
+                              track: {
+                                backgroundColor: doc_group_obj.checked
+                                  ? 'var(--dashboard-button) !important'
+                                  : 'var(--dashboard-background-dark)',
+                                borderColor: doc_group_obj.checked
+                                  ? 'var(--dashboard-button) !important'
+                                  : 'var(--dashboard-background-dark)',
+                              },
+                            }}
+                          />
+                        </span>
+                      </Tooltip>
                     </td>
                   </tr>
                 ))}

--- a/src/components/Chat/__tests__/Chat.test.tsx
+++ b/src/components/Chat/__tests__/Chat.test.tsx
@@ -110,6 +110,7 @@ vi.mock('~/utils/streamProcessing', async (importOriginal) => {
       searchQuery: 'describe image',
       imgDesc: 'an image',
     })),
+    handleContextSearch: vi.fn(async () => []),
   }
 })
 
@@ -1757,6 +1758,61 @@ describe('Chat component', () => {
           arg?.field === 'isRetrievalLoading' && arg?.value === true,
       )
       expect(retrievalCalls.length).toBe(0)
+    })
+
+    it('uses checked document groups for retrieval instead of stale all-documents state', async () => {
+      const user = userEvent.setup()
+      setupStreamHandler()
+      const { handleContextSearch } = await import('~/utils/streamProcessing')
+      ;(handleContextSearch as any).mockClear()
+
+      const conversation = makeConversation({
+        id: 'conv-1',
+        messages: [makeMessage({ id: 'u1', role: 'user', content: 'Hi' })],
+        model: defaultModel,
+      })
+
+      const { Chat } = await import('../Chat')
+
+      renderWithProviders(
+        <Chat
+          stopConversationRef={{ current: false }}
+          courseMetadata={baseCourseMetadata}
+          courseName="CS101"
+          currentEmail="me@example.com"
+          documentExists={true}
+        />,
+        {
+          homeState: {
+            selectedConversation: conversation as any,
+            conversations: [conversation as any],
+            loading: false,
+            messageIsStreaming: false,
+            llmProviders: defaultLLMProviders,
+            apiKey: 'test-key',
+            documentGroups: [
+              { id: 'DocGroup-all', name: 'All Documents', checked: false },
+              { id: 'DocGroup-1', name: 'Group A', checked: true },
+            ],
+          },
+          homeContext: {
+            dispatch: vi.fn(),
+            handleUpdateConversation: vi.fn(),
+            handleFeedbackUpdate: vi.fn(),
+          },
+        },
+      )
+
+      await user.click(screen.getByRole('button', { name: /^send$/i }))
+      await waitFor(() =>
+        expect(handleContextSearch).toHaveBeenCalledWith(
+          expect.any(Object),
+          'CS101',
+          expect.any(Object),
+          expect.any(String),
+          ['Group A'],
+        ),
+      )
     })
   })
 

--- a/src/components/Chat/__tests__/Chat.test.tsx
+++ b/src/components/Chat/__tests__/Chat.test.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest'
 import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
@@ -1754,7 +1762,7 @@ describe('Chat component', () => {
       )
       // Should NOT dispatch isRetrievalLoading
       const retrievalCalls = dispatch.mock.calls.filter(
-        ([arg]: any) =>
+        ([arg]: [{ field?: string; value?: boolean }]) =>
           arg?.field === 'isRetrievalLoading' && arg?.value === true,
       )
       expect(retrievalCalls.length).toBe(0)
@@ -1764,7 +1772,7 @@ describe('Chat component', () => {
       const user = userEvent.setup()
       setupStreamHandler()
       const { handleContextSearch } = await import('~/utils/streamProcessing')
-      ;(handleContextSearch as any).mockClear()
+      ;(handleContextSearch as Mock).mockClear()
 
       const conversation = makeConversation({
         id: 'conv-1',
@@ -1784,8 +1792,8 @@ describe('Chat component', () => {
         />,
         {
           homeState: {
-            selectedConversation: conversation as any,
-            conversations: [conversation as any],
+            selectedConversation: conversation,
+            conversations: [conversation],
             loading: false,
             messageIsStreaming: false,
             llmProviders: defaultLLMProviders,

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -1,6 +1,7 @@
 // src/pages/api/chat-api/chat.ts
 
 import {
+  type ChatApiBody,
   type ChatBody,
   type Content,
   type Conversation,
@@ -65,7 +66,7 @@ export default async function chat(
   }
 
   // Parse and validate the request body
-  const body = req.body
+  const body: ChatApiBody = req.body
   try {
     await validateRequestBody(body)
   } catch (error: any) {
@@ -93,17 +94,6 @@ export default async function chat(
     retrieval_only,
     conversation_id,
     doc_groups: requestedDocGroups,
-  }: {
-    model: string
-    messages: Message[]
-    openai_key: string
-    temperature: number
-    course_name: string
-    stream: boolean
-    api_key: string
-    retrieval_only: boolean
-    conversation_id?: string
-    doc_groups?: string[]
   } = body
 
   // Validate the API key and retrieve user data
@@ -204,11 +194,15 @@ export default async function chat(
     }
   }
 
-  // Preserve caller-provided groups; default to all-documents only when absent.
-  const doc_groups =
-    Array.isArray(requestedDocGroups) && requestedDocGroups.length > 0
-      ? requestedDocGroups
-      : ['All Documents']
+  // Preserve caller-provided groups; filter for non-empty strings; default to all-documents only when absent.
+  let doc_groups = Array.isArray(requestedDocGroups)
+    ? requestedDocGroups.filter(
+        (group) => typeof group === 'string' && group.trim() !== '',
+      )
+    : []
+  if (doc_groups.length === 0) {
+    doc_groups = ['All Documents']
+  }
 
   const controller = new AbortController()
   // Construct the search query
@@ -341,7 +335,7 @@ export default async function chat(
     conversation: updatedConversation,
     key: llmProviders[ProviderNames.OpenAI]?.apiKey as string,
     course_name,
-    stream,
+    stream: stream || false,
     courseMetadata,
     llmProviders,
     mode: 'chat',

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -92,6 +92,7 @@ export default async function chat(
     api_key,
     retrieval_only,
     conversation_id,
+    doc_groups: requestedDocGroups,
   }: {
     model: string
     messages: Message[]
@@ -102,6 +103,7 @@ export default async function chat(
     api_key: string
     retrieval_only: boolean
     conversation_id?: string
+    doc_groups?: string[]
   } = body
 
   // Validate the API key and retrieve user data
@@ -202,9 +204,11 @@ export default async function chat(
     }
   }
 
-  // Fetch document groups
-  // We can fetch custom doc groups here instead, but for now we'll just use the default
-  const doc_groups = ['All Documents']
+  // Preserve caller-provided groups; default to all-documents only when absent.
+  const doc_groups =
+    Array.isArray(requestedDocGroups) && requestedDocGroups.length > 0
+      ? requestedDocGroups
+      : ['All Documents']
 
   const controller = new AbortController()
   // Construct the search query

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -220,6 +220,9 @@ export interface ChatApiBody {
   course_name: string
   stream?: boolean
   api_key: string
+  retrieval_only?: boolean
+  conversation_id?: string
+  doc_groups?: string[]
 }
 
 export interface Action {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -226,4 +226,6 @@ export interface Action {
   id: string
   name: string
   checked: boolean
+  /** Project admin disabled this doc group; user cannot enable it for retrieval */
+  adminDisabled?: boolean
 }

--- a/src/types/courseMaterials.ts
+++ b/src/types/courseMaterials.ts
@@ -11,6 +11,7 @@ export interface CourseDocument {
 }
 
 export interface DocumentGroup {
+  id?: number
   name: string
   enabled: boolean
   course_name: string


### PR DESCRIPTION
**! This PR needs to pair with backend PR: https://github.com/Center-for-AI-Innovation/ai-ta-backend/pull/491**

This PR: 
- Frontend send lastest doc-group selection instead of falling back to stale state. 
- Admin-disabled doc groups UX:
  - In doc-group modal, admin-disabled groups are non-toggleable (Switch disabled).
  - Tooltip explains the reason: “Admin has disabled that doc group.”
- Type updates to pass the lint check

<img width="732" height="439" alt="image" src="https://github.com/user-attachments/assets/6d018f33-a966-4471-81a6-e5a705b6923d" />

