### PR TITLE
feat: Add support for rate limiting in Chat API

### DIFF
--- a/__tests__/pages/api/chat-api/__tests__/chat.test.ts
+++ b/__tests__/pages/api/chat-api/__tests__/chat.test.ts
@@ -11,6 +11,7 @@ const hoisted = vi.hoisted(() => ({
     isValidApiKey: true,
     authContext: { user: { profile: { email: 'u@example.com' } } },
   })),
+  checkRateLimitMiddleware: vi.fn(),
   fetchCourseMetadataServer: vi.fn(async () => ({ is_private: true })),
   determineAndValidateModelServer: vi.fn(async () => ({
     activeModel: { id: 'gpt-4o', name: 'm', tokenLimit: 1, enabled: true },
@@ -42,6 +43,9 @@ const hoisted = vi.hoisted(() => ({
   getBaseUrl: vi.fn(() => 'http://localhost'),
 }))
 
+vi.mock('~/pages/api/chat-api/util/rateLimiting', () => ({
+  checkRateLimitMiddleware: hoisted.checkRateLimitMiddleware,
+}))
 vi.mock('~/pages/api/chat-api/util/fetchCourseMetadataServer', () => ({
   default: hoisted.fetchCourseMetadataServer,
 }))
@@ -134,6 +138,33 @@ describe('chat-api/chat', () => {
       res as any,
     )
     expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('returns 429 and captures event when rate limit is exceeded', async () => {
+    hoisted.checkRateLimitMiddleware.mockResolvedValueOnce(true)
+
+    const res = createMockRes()
+    const req = createMockReq({
+      method: 'POST',
+      body: {
+        model: 'gpt-4o',
+        messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+        temperature: 0.1,
+        course_name: 'CS101',
+        stream: false,
+        api_key: 'k',
+        retrieval_only: false,
+      },
+      socket: { remoteAddress: '127.0.0.1' } as any,
+    })
+
+    await chat(req as any, res as any)
+
+    expect(res.status).toHaveBeenCalledWith(429)
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Too Many Requests',
+    })
+    expect(hoisted.routeModelRequest).not.toHaveBeenCalled()
   })
 
   it('returns 404 when course metadata is missing', async () => {

--- a/__tests__/pages/api/chat-api/util/__tests__/rateLimiting.test.ts
+++ b/__tests__/pages/api/chat-api/util/__tests__/rateLimiting.test.ts
@@ -1,0 +1,122 @@
+/* @vitest-environment node */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { checkRateLimitMiddleware } from 'src/pages/api/chat-api/util/rateLimiting'
+import type { NextApiResponse } from 'next'
+
+// 1. Hoist our mocks so Vitest can use them before imports are resolved
+const hoisted = vi.hoisted(() => {
+  // Mock the Redis transaction pipeline
+  const mockTxn = {
+    zRemRangeByScore: vi.fn().mockReturnThis(),
+    zCard: vi.fn().mockReturnThis(),
+    zAdd: vi.fn().mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
+    exec: vi.fn(),
+  }
+
+  return {
+    mockTxn,
+    mockRedisClient: {
+      multi: vi.fn(() => mockTxn),
+    },
+    ensureRedisConnected: vi.fn(),
+  }
+})
+
+// 2. Mock the module that provides the Redis connection
+vi.mock('~/utils/redisClient', () => ({
+  ensureRedisConnected: hoisted.ensureRedisConnected,
+}))
+
+describe('checkRateLimitMiddleware', () => {
+  let mockRes: Partial<NextApiResponse>
+
+  beforeEach(() => {
+    // Reset all mocks before each test to prevent test pollution
+    vi.clearAllMocks()
+
+    // Setup the mock Redis client to be returned by ensureRedisConnected
+    hoisted.ensureRedisConnected.mockResolvedValue(hoisted.mockRedisClient)
+
+    // Setup a clean mock Response object
+    mockRes = {
+      setHeader: vi.fn(),
+    }
+
+    // Mock Date.now to have predictable timestamps in tests
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns false and sets correct headers when under the rate limit', async () => {
+    // Simulate zCard returning 5 (user has made 5 requests in the window)
+    // The exec array returns the results of [zRemRangeByScore, zCard, zAdd, expire]
+    hoisted.mockTxn.exec.mockResolvedValueOnce(['OK', 5, 'OK', 1])
+
+    const isRateLimited = await checkRateLimitMiddleware(
+      'test_api_key',
+      mockRes as NextApiResponse,
+    )
+
+    // Should NOT be rate limited
+    expect(isRateLimited).toBe(false)
+
+    // Verify Redis commands were called correctly
+    expect(hoisted.mockRedisClient.multi).toHaveBeenCalled()
+    expect(hoisted.mockTxn.zCard).toHaveBeenCalledWith('ratelimit:test_api_key')
+    expect(hoisted.mockTxn.exec).toHaveBeenCalled()
+
+    // Verify Headers
+    // Remaining should be MAX_REQUESTS (10) - zCard count (5) - current request (1) = 4
+    expect(mockRes.setHeader).toHaveBeenNthCalledWith(
+      1,
+      'X-RateLimit-Limit',
+      '10',
+    )
+    expect(mockRes.setHeader).toHaveBeenNthCalledWith(
+      2,
+      'X-RateLimit-Remaining',
+      '4',
+    )
+    expect(mockRes.setHeader).not.toHaveBeenCalledWith(
+      'Retry-After',
+      expect.any(String),
+    )
+  })
+
+  it('returns true and sets Retry-After header when exactly at the rate limit', async () => {
+    // Simulate zCard returning 10 (user has already maxed out their requests)
+    hoisted.mockTxn.exec.mockResolvedValueOnce(['OK', 10, 'OK', 1])
+
+    const isRateLimited = await checkRateLimitMiddleware(
+      'spam_api_key',
+      mockRes as NextApiResponse,
+    )
+
+    // SHOULD be rate limited
+    expect(isRateLimited).toBe(true)
+
+    // Verify Headers
+    expect(mockRes.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', '10')
+    expect(mockRes.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0')
+    // 10000ms window = 10 seconds Retry-After
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Retry-After', '10')
+  })
+
+  it('returns true and limits remaining to 0 when significantly over the rate limit', async () => {
+    // Simulate zCard returning 15 (user is spamming hard)
+    hoisted.mockTxn.exec.mockResolvedValueOnce(['OK', 15, 'OK', 1])
+
+    const isRateLimited = await checkRateLimitMiddleware(
+      'spam_api_key',
+      mockRes as NextApiResponse,
+    )
+
+    expect(isRateLimited).toBe(true)
+    expect(mockRes.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0')
+  })
+})

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -126,7 +126,10 @@ export default async function chat(
     return
   }
 
-  if (await checkRateLimitMiddleware(api_key, res)) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    (await checkRateLimitMiddleware(api_key, res))
+  ) {
     posthog.capture('stream_api_rate_limit_exceeded_api_key', {
       distinct_id: req.headers['x-forwarded-for'] || req.socket.remoteAddress,
       api_key: api_key,

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -126,10 +126,7 @@ export default async function chat(
     return
   }
 
-  if (
-    process.env.NODE_ENV === 'production' &&
-    (await checkRateLimitMiddleware(api_key, res))
-  ) {
+  if (await checkRateLimitMiddleware(api_key, res)) {
     posthog.capture('stream_api_rate_limit_exceeded_api_key', {
       distinct_id: req.headers['x-forwarded-for'] || req.socket.remoteAddress,
       api_key: api_key,

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -39,6 +39,7 @@ import {
 } from '~/utils/modelProviders/LLMProvider'
 import { buildPrompt } from '~/app/utils/buildPromptUtils'
 import { type AuthContextProps } from 'react-oidc-context'
+import { checkRateLimitMiddleware } from './util/rateLimiting'
 
 /**
  * The chat API endpoint for handling chat requests and streaming/non streaming responses.
@@ -122,6 +123,18 @@ export default async function chat(
       user_id: email,
     })
     res.status(403).json({ error: 'Invalid API key' })
+    return
+  }
+
+  if (await checkRateLimitMiddleware(api_key, res)) {
+    posthog.capture('stream_api_rate_limit_exceeded_api_key', {
+      distinct_id: req.headers['x-forwarded-for'] || req.socket.remoteAddress,
+      api_key: api_key,
+      user_id: email,
+    })
+    res.status(429).json({
+      error: 'Too Many Requests',
+    })
     return
   }
 

--- a/src/pages/api/chat-api/util/rateLimiting.ts
+++ b/src/pages/api/chat-api/util/rateLimiting.ts
@@ -1,0 +1,46 @@
+import type { NextApiResponse } from 'next'
+import { ensureRedisConnected } from '~/utils/redisClient'
+
+// 10 requests in 10 seconds (sliding window)
+const MAX_REQUESTS = 10
+const WINDOW_SIZE_IN_MS = 10 * 1000
+
+export async function checkRateLimitMiddleware(
+  key: string,
+  res: NextApiResponse,
+) {
+  const now = Date.now()
+  const windowStart = now - WINDOW_SIZE_IN_MS
+  const redisKey = `ratelimit:${key}`
+
+  try {
+    const redisClient = await ensureRedisConnected()
+
+    const txn = redisClient.multi()
+    txn.zRemRangeByScore(redisKey, 0, windowStart)
+    txn.zCard(redisKey)
+    txn.zAdd(redisKey, [
+      {
+        score: now,
+        value: `${now}-${Math.random().toString(36).substring(2)}`,
+      },
+    ])
+    txn.expire(redisKey, WINDOW_SIZE_IN_MS / 1000)
+
+    const results = await txn.exec()
+    const requestCount = results[1] as number
+    const remaining = Math.max(0, MAX_REQUESTS - requestCount)
+
+    res.setHeader('X-RateLimit-Limit', MAX_REQUESTS.toString())
+    res.setHeader('X-RateLimit-Remaining', remaining.toString())
+
+    if (requestCount >= MAX_REQUESTS) {
+      res.setHeader('Retry-After', (WINDOW_SIZE_IN_MS / 1000).toString())
+      return true
+    }
+    return false
+  } catch (error) {
+    console.error('Rate limiting error:', error)
+    return false
+  }
+}

--- a/src/pages/api/chat-api/util/rateLimiting.ts
+++ b/src/pages/api/chat-api/util/rateLimiting.ts
@@ -29,7 +29,7 @@ export async function checkRateLimitMiddleware(
 
     const results = await txn.exec()
     const requestCount = results[1] as number
-    const remaining = Math.max(0, MAX_REQUESTS - requestCount)
+    const remaining = Math.max(0, MAX_REQUESTS - (requestCount + 1))
 
     res.setHeader('X-RateLimit-Limit', MAX_REQUESTS.toString())
     res.setHeader('X-RateLimit-Remaining', remaining.toString())


### PR DESCRIPTION
Fixes https://github.com/Center-for-AI-Innovation/illinois.chat/issues/99

Current limit: 10 requests in 10 seconds (sliding window)