### PR TITLE
Encode course_name for all API calls and add course name validations on create

### DIFF
--- a/src/components/UIUC-Components/ApiKeyManagament.tsx
+++ b/src/components/UIUC-Components/ApiKeyManagament.tsx
@@ -190,7 +190,9 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
         return
       }
       const response = await fetch(
-        `/api/chat-api/keys/fetch?course_name=${course_name}`,
+        `/api/chat-api/keys/fetch?course_name=${encodeURIComponent(
+          course_name,
+        )}`,
       )
 
       if (response.ok) {
@@ -211,7 +213,9 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
 
   const handleGenerate = async () => {
     const response = await fetch(
-      `/api/chat-api/keys/generate?course_name=${course_name}`,
+      `/api/chat-api/keys/generate?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
       {
         method: 'POST',
         headers: {
@@ -238,7 +242,9 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
 
   const handleRotate = async () => {
     const response = await fetch(
-      `/api/chat-api/keys/rotate?course_name=${course_name}`,
+      `/api/chat-api/keys/rotate?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
       {
         method: 'PUT',
       },
@@ -262,7 +268,9 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
 
   const handleDelete = async () => {
     const response = await fetch(
-      `/api/chat-api/keys/delete?course_name=${course_name}`,
+      `/api/chat-api/keys/delete?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
       {
         method: 'DELETE',
       },

--- a/src/components/UIUC-Components/CannotViewCourse.tsx
+++ b/src/components/UIUC-Components/CannotViewCourse.tsx
@@ -9,6 +9,7 @@ import { useAuth } from 'react-oidc-context'
 import { CannotEditCourse } from './CannotEditCourse'
 import GlobalFooter from './GlobalFooter'
 import { montserrat_heading } from 'fonts'
+import { useFetchCourseMetadata } from '~/hooks/queries/useFetchCourseMetadata'
 
 export const GetCurrentPageName = () => {
   // /CS-125/dashboard --> CS-125
@@ -27,38 +28,9 @@ export const CannotViewCourse = ({
   const auth = useAuth()
   const curr_user_email = auth.user?.profile.email
 
-  const [courseMetadata, setCourseMetadata] = useState<CourseMetadata | null>(
-    null,
-  )
-
-  useEffect(() => {
-    async function fetchCourseMetadata(course_name: string) {
-      try {
-        const response = await fetch(
-          `/api/UIUC-api/getCourseMetadata?course_name=${course_name}`,
-        )
-
-        if (response.ok) {
-          const data = await response.json()
-          if (data.success === false) {
-            console.error('An error occurred while fetching course metadata')
-            return null
-          }
-          return data.course_metadata
-        } else {
-          console.error(`Error fetching course metadata: ${response.status}`)
-          return null
-        }
-      } catch (error) {
-        console.error('Error fetching course metadata:', error)
-        return null
-      }
-    }
-
-    fetchCourseMetadata(course_name).then((metadata) => {
-      setCourseMetadata(metadata)
-    })
-  }, [course_name])
+  const { data: courseMetadata = null } = useFetchCourseMetadata({
+    courseName: course_name,
+  })
 
   // if user is not signed in or is not the creator or an admin, then they cannot view the course
 

--- a/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -193,11 +193,11 @@ export default function GitHubIngestForm({
   useEffect(() => {
     const checkIngestStatus = async () => {
       const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${project_name}`,
+        `/api/materialsTable/docsInProgress?course_name=${encodeURIComponent(project_name)}`,
       )
       const data = await response.json()
       const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${project_name}`,
+        `/api/materialsTable/successDocs?course_name=${encodeURIComponent(project_name)}`,
       )
       const docsData = await docsResponse.json()
 

--- a/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/src/components/UIUC-Components/LargeDropzone.tsx
@@ -258,12 +258,12 @@ export function LargeDropzone({
 
     const checkIngestStatus = async () => {
       const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${courseName}`,
+        `/api/materialsTable/docsInProgress?course_name=${encodeURIComponent(courseName)}`,
       )
       const data = await response.json()
 
       const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${courseName}`,
+        `/api/materialsTable/successDocs?course_name=${encodeURIComponent(courseName)}`,
       )
       const docsData = await docsResponse.json()
       // Adjust polling interval based on activity

--- a/src/components/UIUC-Components/MakeNewCoursePage.tsx
+++ b/src/components/UIUC-Components/MakeNewCoursePage.tsx
@@ -83,14 +83,16 @@ const MakeNewCoursePage = ({
   // Debounce project name input to avoid excessive API calls
   const [debouncedProjectName] = useDebouncedValue(projectName, 1000)
 
+  const isCourseNameValid =
+    debouncedProjectName.length > 0 &&
+    checkCourseNameValid(debouncedProjectName)
+
   // Check project name availability using React Query
   const { data: courseExists = false, isFetching: isCheckingAvailability } =
     useFetchCourseExists({
       courseName: debouncedProjectName.toLowerCase(), // Normalize to lowercase for consistency
-      enabled: debouncedProjectName.length > 0 && is_new_course,
+      enabled: isCourseNameValid && is_new_course,
     })
-
-  const isCourseNameValid = checkCourseNameValid(projectName)
 
   // Calculate availability: course exists = not available
   const isCourseAvailable =

--- a/src/components/UIUC-Components/MakeNewCoursePage.tsx
+++ b/src/components/UIUC-Components/MakeNewCoursePage.tsx
@@ -7,8 +7,8 @@ import { Button } from '@/components/shadcn/ui/button'
 import { LoaderCircle } from 'lucide-react'
 import { useDebouncedValue } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { createProject } from '~/utils/apiUtils'
+import { useQueryClient } from '@tanstack/react-query'
+import { checkCourseNameValid, createProject } from '~/utils/apiUtils'
 import { fetchCourseMetadata } from '~/utils/apiUtils'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import Navbar from './navbars/Navbar'
@@ -23,6 +23,7 @@ import StepSuccess from './MakeNewCoursePageSteps/StepSuccess'
 import { useAuth } from 'react-oidc-context'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import GlobalFooter from './GlobalFooter'
+import { useFetchCourseExists } from '~/hooks/queries/useFetchCourseExists'
 
 /**
  * Build a safe relative URL for navigating to a project's chat page.
@@ -83,36 +84,19 @@ const MakeNewCoursePage = ({
   const [debouncedProjectName] = useDebouncedValue(projectName, 1000)
 
   // Check project name availability using React Query
-  const { data: courseExists, isFetching: isCheckingAvailability } =
-    useQuery<boolean>({
-      queryKey: ['projectNameAvailability', debouncedProjectName],
-      queryFn: async () => {
-        if (!debouncedProjectName || debouncedProjectName.length === 0) {
-          return false
-        }
-        const response = await fetch(
-          `/api/UIUC-api/getCourseExists?course_name=${encodeURIComponent(
-            debouncedProjectName,
-          )}`,
-        )
-        if (!response.ok) {
-          throw new Error('Failed to check project name availability')
-        }
-        return response.json() as Promise<boolean>
-      },
+  const { data: courseExists = false, isFetching: isCheckingAvailability } =
+    useFetchCourseExists({
+      courseName: debouncedProjectName.toLowerCase(), // Normalize to lowercase for consistency
       enabled: debouncedProjectName.length > 0 && is_new_course,
-      retry: 1,
     })
+
+  const isCourseNameValid = checkCourseNameValid(projectName)
 
   // Calculate availability: course exists = not available
   const isCourseAvailable =
     debouncedProjectName.length === 0
       ? undefined
-      : courseExists === false
-        ? true
-        : courseExists === true
-          ? false
-          : undefined
+      : isCourseNameValid && !courseExists
 
   // Check if we're waiting for debounce or API response
   const isWaitingForAvailabilityCheck =
@@ -145,6 +129,7 @@ const MakeNewCoursePage = ({
       project_description={projectDescription}
       is_new_course={!hasCreatedProject}
       isCourseAvailable={isCourseAvailable}
+      isCourseNameValid={isCourseNameValid}
       isCheckingAvailability={isWaitingForAvailabilityCheck}
       onUpdateName={setProjectName}
       onUpdateDescription={setProjectDescription}
@@ -218,7 +203,7 @@ const MakeNewCoursePage = ({
     setIsLoading(true)
     try {
       const result = await createProject(
-        project_name,
+        project_name.toLowerCase(), // Normalize to lowercase for consistency
         project_description,
         current_user_email,
         is_private,

--- a/src/components/UIUC-Components/MakeNewCoursePageSteps/StepCreate.tsx
+++ b/src/components/UIUC-Components/MakeNewCoursePageSteps/StepCreate.tsx
@@ -20,6 +20,7 @@ const StepCreate = ({
   is_new_course = true,
   project_description,
   isCourseAvailable,
+  isCourseNameValid,
   isCheckingAvailability,
 
   onUpdateName,
@@ -29,6 +30,7 @@ const StepCreate = ({
   is_new_course?: boolean
   project_description?: string
   isCourseAvailable?: boolean
+  isCourseNameValid?: boolean
   isCheckingAvailability?: boolean
 
   onUpdateName: (name: string) => void
@@ -94,6 +96,14 @@ const StepCreate = ({
                         Checking name availability...
                       </span>
                     </span>
+                  ) : !isCourseNameValid && projectName ? (
+                    <span role="status">
+                      <XCircle
+                        className="size-4 text-red-500"
+                        aria-hidden="true"
+                      />
+                      <span className="sr-only">Name is invalid</span>
+                    </span>
                   ) : isCourseAvailable && projectName ? (
                     <span role="status">
                       <CheckCircle
@@ -123,7 +133,10 @@ const StepCreate = ({
               side="right"
               className="border-red-500 bg-red-500 text-white"
             >
-              This name is already taken. Please choose a different name.
+              {isCourseNameValid
+                ? 'This name is already taken.'
+                : 'This name is invalid.'}{' '}
+              Please choose a different name.
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/components/UIUC-Components/MakeNewCoursePageSteps/__tests__/StepCreate.test.tsx
+++ b/src/components/UIUC-Components/MakeNewCoursePageSteps/__tests__/StepCreate.test.tsx
@@ -21,6 +21,7 @@ describe('StepCreate', () => {
     is_new_course: true,
     project_description: '',
     isCourseAvailable: undefined as boolean | undefined,
+    isCourseNameValid: undefined as boolean | undefined,
     isCheckingAvailability: false,
     onUpdateName: vi.fn(),
     onUpdateDescription: vi.fn(),
@@ -131,6 +132,7 @@ describe('StepCreate', () => {
         {...defaultProps}
         project_name="test"
         isCourseAvailable={true}
+        isCourseNameValid={true}
         isCheckingAvailability={false}
       />,
     )
@@ -143,10 +145,24 @@ describe('StepCreate', () => {
         {...defaultProps}
         project_name="test"
         isCourseAvailable={false}
+        isCourseNameValid={true}
         isCheckingAvailability={false}
       />,
     )
     expect(screen.getByText('Name is already taken')).toBeInTheDocument()
+  })
+
+  it('shows invalid status when name is invalid', () => {
+    render(
+      <StepCreate
+        {...defaultProps}
+        project_name="test"
+        isCourseAvailable={false}
+        isCourseNameValid={false}
+        isCheckingAvailability={false}
+      />,
+    )
+    expect(screen.getByText('Name is invalid')).toBeInTheDocument()
   })
 
   it('renders error status icon when name is taken', () => {
@@ -155,11 +171,29 @@ describe('StepCreate', () => {
         {...defaultProps}
         project_name="test"
         isCourseAvailable={false}
+        isCourseNameValid={true}
         isCheckingAvailability={false}
       />,
     )
     // The error status icon and sr-only text are rendered
     expect(screen.getByText('Name is already taken')).toBeInTheDocument()
+    // Status container has role="status"
+    const statusEl = container.querySelector('[role="status"]')
+    expect(statusEl).toBeInTheDocument()
+  })
+
+  it('renders error status icon when name is invalid', () => {
+    const { container } = render(
+      <StepCreate
+        {...defaultProps}
+        project_name="test"
+        isCourseAvailable={false}
+        isCourseNameValid={false}
+        isCheckingAvailability={false}
+      />,
+    )
+    // The error status icon and sr-only text are rendered
+    expect(screen.getByText('Name is invalid')).toBeInTheDocument()
     // Status container has role="status"
     const statusEl = container.querySelector('[role="status"]')
     expect(statusEl).toBeInTheDocument()

--- a/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
+++ b/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
@@ -125,9 +125,7 @@ const formatPercentageChange = (value: number | null | undefined) => {
 const MakeQueryAnalysisPage = ({ course_name }: { course_name: string }) => {
   const { classes, theme } = useStyles()
   const auth = useAuth()
-  const [courseMetadata, setCourseMetadata] = useState<CourseMetadata | null>(
-    null,
-  )
+
   const [currentEmail, setCurrentEmail] = useState('')
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
     getInitialCollapsedState(),
@@ -181,29 +179,14 @@ const MakeQueryAnalysisPage = ({ course_name }: { course_name: string }) => {
     null,
   )
 
+  const { data: courseMetadata = null } = useFetchCourseMetadata({
+    courseName: currentPageName,
+  })
+
   // TODO: remove this hook... we should already have this from the /materials props???
   useEffect(() => {
-    const fetchData = async () => {
-      setCurrentEmail(auth.user?.profile.email as string)
-
-      try {
-        const metadata: CourseMetadata = (await fetchCourseMetadata(
-          currentPageName,
-        )) as CourseMetadata
-
-        if (metadata && metadata.is_private) {
-          metadata.is_private = JSON.parse(
-            metadata.is_private as unknown as string,
-          )
-        }
-        setCourseMetadata(metadata)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-
-    fetchData()
-  }, [currentPageName, !auth.isLoading, auth.user])
+    setCurrentEmail(auth.user?.profile.email as string)
+  }, [!auth.isLoading, auth.user])
 
   const [hasConversationData, setHasConversationData] = useState<boolean>(true)
 
@@ -1243,40 +1226,7 @@ import GlobalFooter from './GlobalFooter'
 
 import Link from 'next/link'
 import NomicDocumentMap from './NomicDocumentsMap'
-
-async function fetchCourseMetadata(course_name: string) {
-  try {
-    const response = await fetch(
-      `/api/UIUC-api/getCourseMetadata?course_name=${course_name}`,
-    )
-    if (response.ok) {
-      const data = await response.json()
-      if (data.success === false) {
-        throw new Error(
-          data.message || 'An error occurred while fetching course metadata',
-        )
-      }
-      // Parse is_private field from string to boolean
-      if (
-        data.course_metadata &&
-        typeof data.course_metadata.is_private === 'string'
-      ) {
-        data.course_metadata.is_private =
-          data.course_metadata.is_private.toLowerCase() === 'true'
-      }
-      return data.course_metadata
-    } else {
-      throw new Error(
-        `Error fetching course metadata: ${
-          response.statusText || response.status
-        }`,
-      )
-    }
-  } catch (error) {
-    console.error('Error fetching course metadata:', error)
-    throw error
-  }
-}
+import { useFetchCourseMetadata } from '~/hooks/queries/useFetchCourseMetadata'
 
 const showToastOnFileDeleted = (theme: MantineTheme, was_error = false) => {
   return (

--- a/src/components/UIUC-Components/NomicDocumentsMap.tsx
+++ b/src/components/UIUC-Components/NomicDocumentsMap.tsx
@@ -15,7 +15,7 @@ function NomicDocumentMap({ course_name }: { course_name: string }) {
     const fetchNomicMapData = async () => {
       try {
         const response = await fetch(
-          `/api/getNomicMapForQueries?course_name=${course_name}&map_type=conversation`,
+          `/api/getNomicMapForQueries?course_name=${encodeURIComponent(course_name)}&map_type=conversation`,
         )
 
         const responseText = await response.text()

--- a/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -187,7 +187,11 @@ export function ProjectFilesTable({
       const to = from + PAGE_SIZE - 1
 
       const response = await fetch(
-        `/api/materialsTable/fetchProjectMaterials?from=${from}&to=${to}&course_name=${course_name}&filter_key=${filterKey}&filter_value=${filterValue}&sort_column=${sortStatus.columnAccessor}&sort_direction=${sortStatus.direction}`,
+        `/api/materialsTable/fetchProjectMaterials?from=${from}&to=${to}&course_name=${encodeURIComponent(
+          course_name,
+        )}&filter_key=${filterKey}&filter_value=${filterValue}&sort_column=${
+          sortStatus.columnAccessor
+        }&sort_direction=${sortStatus.direction}`,
       )
       if (!response.ok) {
         throw new Error('Failed to fetch document groups')
@@ -218,7 +222,11 @@ export function ProjectFilesTable({
       const from = (page - 1) * PAGE_SIZE
       const to = from + PAGE_SIZE - 1
       const response = await fetch(
-        `/api/materialsTable/fetchFailedDocuments?from=${from}&to=${to}&course_name=${course_name}&filter_key=${filterKey}&filter_value=${filterValue}&sort_column=${sortStatus.columnAccessor}&sort_direction=${sortStatus.direction}`,
+        `/api/materialsTable/fetchFailedDocuments?from=${from}&to=${to}&course_name=${encodeURIComponent(
+          course_name,
+        )}&filter_key=${filterKey}&filter_value=${filterValue}&sort_column=${
+          sortStatus.columnAccessor
+        }&sort_direction=${sortStatus.direction}`,
       )
       if (!response.ok) {
         throw new Error('Failed to fetch failed documents')

--- a/src/components/UIUC-Components/UploadNotification.tsx
+++ b/src/components/UIUC-Components/UploadNotification.tsx
@@ -73,7 +73,9 @@ function UploadNotificationContent({
       const sort_direction = 'desc'
 
       const response = await fetch(
-        `/api/materialsTable/fetchFailedDocuments?from=${from}&to=${to}&course_name=${projectName}&filter_key=${filter_key}&filter_value=${filter_value}&sort_column=${sort_column}&sort_direction=${sort_direction}`,
+        `/api/materialsTable/fetchFailedDocuments?from=${from}&to=${to}&course_name=${encodeURIComponent(
+          projectName,
+        )}&filter_key=${filter_key}&filter_value=${filter_value}&sort_column=${sort_column}&sort_direction=${sort_direction}`,
       )
       if (!response.ok) {
         throw new Error('Failed to fetch failed documents')

--- a/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -184,11 +184,15 @@ export default function WebsiteIngestForm({
   useEffect(() => {
     const checkIngestStatus = async () => {
       const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${project_name}`,
+        `/api/materialsTable/docsInProgress?course_name=${encodeURIComponent(
+          project_name,
+        )}`,
       )
       const data = await response.json()
       const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${project_name}`,
+        `/api/materialsTable/successDocs?course_name=${encodeURIComponent(
+          project_name,
+        )}`,
       )
       const docsData = await docsResponse.json()
       // Helper function to organize docs by base URL

--- a/src/components/UIUC-Components/__tests__/MakeNewCoursePage.test.tsx
+++ b/src/components/UIUC-Components/__tests__/MakeNewCoursePage.test.tsx
@@ -460,7 +460,7 @@ describe('MakeNewCoursePage', () => {
 
       await waitFor(() => {
         expect(apiUtils.createProject).toHaveBeenCalledWith(
-          'NewBot',
+          'newbot',
           '',
           'owner@example.com',
           true, // useIllinoisChatConfig = true
@@ -1242,7 +1242,7 @@ describe('MakeNewCoursePage', () => {
 
       await waitFor(() => {
         expect(apiUtils.createProject).toHaveBeenCalledWith(
-          'DescTest',
+          'desctest',
           'A test project',
           'owner@example.com',
           true,
@@ -1302,7 +1302,7 @@ describe('MakeNewCoursePage', () => {
 
       await waitFor(() => {
         expect(apiUtils.createProject).toHaveBeenCalledWith(
-          'DescTest',
+          'desctest',
           'My new description',
           'owner@example.com',
           true,

--- a/src/components/UIUC-Components/navbars/ChatNavbar.tsx
+++ b/src/components/UIUC-Components/navbars/ChatNavbar.tsx
@@ -22,6 +22,7 @@ import HomeContext from '~/pages/api/home/home.context'
 import { UserSettings } from '../../Chat/UserSettings'
 import { ThemeToggle } from '../ThemeToggle'
 import { AuthMenu } from './AuthMenu'
+import { useFetchCourseMetadata } from '~/hooks/queries/useFetchCourseMetadata'
 
 const styles: Record<string, React.CSSProperties> = {
   logoContainerBox: {
@@ -182,36 +183,31 @@ const ChatNavbar = ({ bannerUrl = '', isgpt4 = true }: ChatNavbarProps) => {
     return router.asPath.split('/')[1]
   }
 
+  const { data: courseMetadata = null } = useFetchCourseMetadata({
+    courseName: getCurrentCourseName() || '',
+    enabled: auth.isAuthenticated,
+  })
+
   useEffect(() => {
-    const fetchCourses = async () => {
-      if (auth.isAuthenticated) {
-        const userEmail = auth.user?.profile.email
-        const currUserEmails = userEmail ? [userEmail] : []
-        posthog?.identify(auth.user?.profile.sub, {
-          email: currUserEmails[0] || 'no_email',
-        })
+    if (!auth.isAuthenticated || !courseMetadata) return
 
-        const response = await fetch(
-          `/api/UIUC-api/getCourseMetadata?course_name=${getCurrentCourseName()}`,
-        )
-        const courseMetadata = await response.json().then((data) => {
-          return data['course_metadata']
-        })
+    const userEmail = auth.user?.profile.email
+    const currUserEmails = userEmail ? [userEmail] : []
+    posthog?.identify(auth.user?.profile.sub, {
+      email: currUserEmails[0] || 'no_email',
+    })
 
-        if (
-          currUserEmails.includes(courseMetadata.course_owner) ||
-          currUserEmails.some((email) =>
-            courseMetadata.course_admins?.includes(email),
-          )
-        ) {
-          setIsAdminOrOwner(true)
-        } else {
-          setIsAdminOrOwner(false)
-        }
-      }
+    if (
+      currUserEmails.includes(courseMetadata.course_owner) ||
+      currUserEmails.some((email) =>
+        courseMetadata.course_admins?.includes(email),
+      )
+    ) {
+      setIsAdminOrOwner(true)
+    } else {
+      setIsAdminOrOwner(false)
     }
-    fetchCourses()
-  }, [auth.isAuthenticated])
+  }, [auth.isAuthenticated, courseMetadata])
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/hooks/__internal__/conversation.ts
+++ b/src/hooks/__internal__/conversation.ts
@@ -22,7 +22,9 @@ export async function fetchConversationHistory(
   }
   try {
     const response = await fetch(
-      `/api/conversation?searchTerm=${searchTerm}&courseName=${courseName}&pageParam=${pageParam}`,
+      `/api/conversation?searchTerm=${encodeURIComponent(
+        searchTerm,
+      )}&courseName=${encodeURIComponent(courseName)}&pageParam=${pageParam}`,
       {
         method: 'GET',
         headers: createHeaders(userEmail),
@@ -103,7 +105,9 @@ export async function fetchLastConversation(
   try {
     // Grab the first page; server already orders by updated_at DESC in your SQL,
     const res = await fetch(
-      `/api/conversation?searchTerm=&courseName=${encodeURIComponent(courseName)}&pageParam=0`,
+      `/api/conversation?searchTerm=&courseName=${encodeURIComponent(
+        courseName,
+      )}&pageParam=0`,
       {
         method: 'GET',
         headers: createHeaders(userEmail),

--- a/src/hooks/__internal__/folders.ts
+++ b/src/hooks/__internal__/folders.ts
@@ -11,7 +11,9 @@ export async function fetchFolders(
   let fetchedFolders = []
   try {
     const foldersResonse = await fetch(
-      `/api/folder?courseName=${course_name}&searchTerm=${searchTerm}`,
+      `/api/folder?courseName=${encodeURIComponent(
+        course_name,
+      )}&searchTerm=${encodeURIComponent(searchTerm || '')}`,
       {
         method: 'GET',
         headers: createHeaders(userEmail),

--- a/src/hooks/queries/useFetchCourseExists.ts
+++ b/src/hooks/queries/useFetchCourseExists.ts
@@ -16,7 +16,9 @@ async function fetchCourseExists({
   courseName,
 }: FetchCourseExistsVariables): Promise<boolean> {
   const response = await fetch(
-    `/api/UIUC-api/getCourseExists?course_name=${courseName}`,
+    `/api/UIUC-api/getCourseExists?course_name=${encodeURIComponent(
+      courseName,
+    )}`,
   )
 
   if (!response.ok) {
@@ -24,7 +26,7 @@ async function fetchCourseExists({
   }
 
   const data: CourseExistsResponse = await response.json()
-  return Boolean(data.exists)
+  return Boolean(data)
 }
 
 export function useFetchCourseExists({

--- a/src/hooks/queries/useFetchCourseMetadata.ts
+++ b/src/hooks/queries/useFetchCourseMetadata.ts
@@ -13,12 +13,16 @@ interface UseFetchCourseMetadataOptions extends FetchCourseMetadataVariables {
 async function fetchCourseMetadata({
   courseName,
 }: FetchCourseMetadataVariables): Promise<CourseMetadata> {
-  const endpoint = `${getBaseUrl()}/api/UIUC-api/getCourseMetadata?course_name=${courseName}`
+  const endpoint = `${getBaseUrl()}/api/UIUC-api/getCourseMetadata?course_name=${encodeURIComponent(
+    courseName,
+  )}`
   const response = await fetch(endpoint)
 
   if (!response.ok) {
     throw new Error(
-      `Error fetching course metadata: ${response.statusText || response.status}`,
+      `Error fetching course metadata: ${
+        response.statusText || response.status
+      }`,
     )
   }
 

--- a/src/pages/[course_name]/chat.tsx
+++ b/src/pages/[course_name]/chat.tsx
@@ -71,7 +71,7 @@ const ChatPage: NextPage = () => {
       // Fetch course metadata
       try {
         const metadataResponse = await fetch(
-          `/api/UIUC-api/getCourseMetadata?course_name=${courseName}`,
+          `/api/UIUC-api/getCourseMetadata?course_name=${encodeURIComponent(courseName)}`,
         )
 
         if (!metadataResponse.ok) {

--- a/src/pages/[course_name]/chat.tsx
+++ b/src/pages/[course_name]/chat.tsx
@@ -71,7 +71,9 @@ const ChatPage: NextPage = () => {
       // Fetch course metadata
       try {
         const metadataResponse = await fetch(
-          `/api/UIUC-api/getCourseMetadata?course_name=${encodeURIComponent(courseName)}`,
+          `/api/UIUC-api/getCourseMetadata?course_name=${encodeURIComponent(
+            courseName,
+          )}`,
         )
 
         if (!metadataResponse.ok) {
@@ -115,7 +117,9 @@ const ChatPage: NextPage = () => {
     const fetchDocumentExists = async () => {
       try {
         const docCountResponse = await fetch(
-          `/api/materialsTable/fetchIfDocumentExists?course_name=${courseName}`,
+          `/api/materialsTable/fetchIfDocumentExists?course_name=${encodeURIComponent(
+            courseName,
+          )}`,
         )
 
         const docCountData = await docCountResponse.json()

--- a/src/pages/[course_name]/prompt.tsx
+++ b/src/pages/[course_name]/prompt.tsx
@@ -22,8 +22,8 @@ import SettingsLayout, {
 import PromptEditor from '~/components/UIUC-Components/PromptEditor'
 import { useResponsiveCardWidth } from '~/utils/responsiveGrid'
 import GlobalFooter from '../../components/UIUC-Components/GlobalFooter'
-import { type CourseMetadata } from '~/types/courseMetadata'
-import { fetchCourseMetadata } from '~/utils/apiUtils'
+import { useFetchCourseExists } from '~/hooks/queries/useFetchCourseExists'
+import { useFetchCourseMetadata } from '~/hooks/queries/useFetchCourseMetadata'
 
 const montserrat = Montserrat({
   weight: '700',
@@ -47,46 +47,41 @@ const CourseMain: NextPage = () => {
   const isLoaded = !auth.isLoading
   const isSignedIn = auth.isAuthenticated
   const user = auth.user
-  const [courseExists, setCourseExists] = useState<boolean | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(
     getInitialCollapsedState(),
   )
-  const [errorType, setErrorType] = useState<401 | 403 | 404 | null>(null)
 
   const cardWidthClasses = useResponsiveCardWidth(sidebarCollapsed)
 
-  useEffect(() => {
-    if (!router.isReady || auth.isLoading) return
-    const fetchCourseData = async () => {
-      setIsLoading(true)
-      const response = await fetch(
-        `/api/UIUC-api/getCourseExists?course_name=${courseName}`,
-      )
-      const data = await response.json()
-      setCourseExists(data)
-      try {
-        const fetchedMetadata: CourseMetadata = (await fetchCourseMetadata(
-          courseName,
-        )) as CourseMetadata
-        if (fetchedMetadata === null) {
-          setErrorType(404)
-          return
-        }
-      } catch (error) {
-        console.error(error)
+  const {
+    isLoading: isCourseExistsLoading = false,
+    data: courseExists = false,
+  } = useFetchCourseExists({
+    courseName,
+    enabled: router.isReady && isLoaded,
+  })
 
-        const errorWithStatus = error as Error & { status?: number }
-        const status = errorWithStatus.status
-        if (status === 401 || status === 403 || status === 404) {
-          setErrorType(status as 401 | 403 | 404)
-        }
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    fetchCourseData()
-  }, [router.isReady, auth.isLoading, courseName])
+  const fetchCourseMetadataResponse = useFetchCourseMetadata({
+    courseName,
+    enabled: router.isReady && isLoaded && courseExists,
+  })
+
+  const {
+    isLoading: isCourseMetadataLoading = false,
+    data: courseMetadata = null,
+    error: courseMetadataError,
+  } = fetchCourseMetadataResponse || {}
+
+  const isLoading = isCourseExistsLoading || isCourseMetadataLoading
+  const errorType =
+    !courseExists || courseMetadata === null
+      ? 404
+      : courseMetadataError
+        ? ((courseMetadataError as Error & { status?: number }).status as
+            | 401
+            | 403
+            | 404)
+        : null
 
   if (!isLoaded || isLoading) {
     return <LoadingPlaceholderForAdminPages />

--- a/src/pages/[course_name]/tools.tsx
+++ b/src/pages/[course_name]/tools.tsx
@@ -14,6 +14,7 @@ import { Title } from '@mantine/core'
 import MakeToolsPage from '~/components/UIUC-Components/N8NPage'
 import posthog from 'posthog-js'
 import { useAuth } from 'react-oidc-context'
+import { useFetchCourseExists } from '~/hooks/queries/useFetchCourseExists'
 
 const montserrat = Montserrat({
   weight: '700',
@@ -38,40 +39,39 @@ const ToolsPage: NextPage = () => {
   }
   const courseName = getCurrentPageName() as string
 
+  const {
+    isLoading: isCourseExistsLoading = true,
+    data: courseExists = false,
+  } = useFetchCourseExists({
+    courseName,
+    enabled: router.isReady && !auth.isLoading,
+  })
+
   useEffect(() => {
     if (!router.isReady || auth.isLoading) return
+
+    if (!courseExists) {
+      setErrorType(404)
+      return
+    }
 
     const fetchCourseData = async () => {
       setIsLoading(true)
       try {
-        const exsitResponse = await fetch(
-          `/api/UIUC-api/getCourseExists?course_name=${courseName}`,
+        const dataResponse = await fetch(
+          `/api/UIUC-api/getAllCourseData?course_name=${encodeURIComponent(
+            courseName,
+          )}`,
         )
-        if (!exsitResponse.ok) {
-          const s = exsitResponse.status
+        if (!dataResponse.ok) {
+          const s = dataResponse.status
           if (s === 401 || s === 403 || s === 404)
             setErrorType(s as 401 | 403 | 404)
           return
         }
-
-        const data = await exsitResponse.json()
-        if (!data) {
-          setErrorType(404)
-          return
-        } else {
-          const dataResponse = await fetch(
-            `/api/UIUC-api/getAllCourseData?course_name=${courseName}`,
-          )
-          if (!dataResponse.ok) {
-            const s = dataResponse.status
-            if (s === 401 || s === 403 || s === 404)
-              setErrorType(s as 401 | 403 | 404)
-            return
-          }
-          const data = await dataResponse.json()
-          const courseData = data.distinct_files
-          setCourseData(courseData)
-        }
+        const data = await dataResponse.json()
+        const courseData = data.distinct_files
+        setCourseData(courseData)
       } catch (error) {
         console.error(error)
 
@@ -89,9 +89,14 @@ const ToolsPage: NextPage = () => {
       })
     }
     fetchCourseData()
-  }, [router.isReady, auth.isLoading, courseName])
+  }, [router.isReady, auth.isLoading, courseName, courseExists])
 
-  if (auth.isLoading || isLoading || courseName === undefined) {
+  if (
+    auth.isLoading ||
+    isLoading ||
+    isCourseExistsLoading ||
+    courseName === undefined
+  ) {
     return <LoadingPlaceholderForAdminPages />
   }
 

--- a/src/pages/api/UIUC-api/createProject.ts
+++ b/src/pages/api/UIUC-api/createProject.ts
@@ -3,6 +3,12 @@ import { withAuth, type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { getBackendUrl } from '~/utils/apiUtils'
 import { checkCourseExists } from './getCourseExists'
 
+// Allow only letters, numbers, and hyphens in course names
+const regex = /^[a-zA-Z0-9-]+$/
+const checkCourseNameValid = (courseName: string): boolean => {
+  return regex.test(courseName)
+}
+
 async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -17,10 +23,19 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     })
   }
 
+  if (!checkCourseNameValid(project_name)) {
+    return res.status(400).json({
+      error:
+        'Invalid project name. Only letters, numbers, and hyphens are allowed.',
+    })
+  }
+
+  const norm_project_name = project_name.toLowerCase() // Normalize project name to lowercase for consistency
+
   // Server-side validation: Check if project name already exists
   // This prevents race conditions where a user could bypass client-side validation
   try {
-    const projectExists = await checkCourseExists(project_name)
+    const projectExists = await checkCourseExists(norm_project_name)
 
     if (projectExists) {
       return res.status(409).json({
@@ -39,7 +54,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
   }
 
   const requestBody = {
-    project_name: project_name,
+    project_name: norm_project_name,
     project_description: project_description,
     project_owner_email: project_owner_email,
     is_private: is_private,

--- a/src/pages/api/UIUC-api/createProject.ts
+++ b/src/pages/api/UIUC-api/createProject.ts
@@ -3,8 +3,8 @@ import { withAuth, type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { getBackendUrl } from '~/utils/apiUtils'
 import { checkCourseExists } from './getCourseExists'
 
-// Allow only letters, numbers, and hyphens in course names
-const regex = /^[a-zA-Z0-9-]+$/
+// Allow only letters, numbers, and hyphens in course names, cannot start with a hyphen
+const regex = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/
 const checkCourseNameValid = (courseName: string): boolean => {
   return regex.test(courseName)
 }

--- a/src/pages/api/UIUC-api/getAllCourseData.ts
+++ b/src/pages/api/UIUC-api/getAllCourseData.ts
@@ -15,7 +15,9 @@ async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${getBackendUrl()}/getAll?course_name=${course_name}`,
+      `${getBackendUrl()}/getAll?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getModelUsageCounts.ts
+++ b/src/pages/api/UIUC-api/getModelUsageCounts.ts
@@ -21,7 +21,9 @@ async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${getBackendUrl()}/getModelUsageCounts?project_name=${project_name}`,
+      `${getBackendUrl()}/getModelUsageCounts?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {
@@ -48,7 +50,9 @@ export async function getModelUsageCounts(project_name: string) {
   try {
     console.log('Fetching model usage counts for project:', project_name)
     const response = await fetch(
-      `/api/UIUC-api/getModelUsageCounts?project_name=${project_name}`,
+      `/api/UIUC-api/getModelUsageCounts?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getProjectStats.ts
+++ b/src/pages/api/UIUC-api/getProjectStats.ts
@@ -15,7 +15,9 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
   try {
     const response = await fetch(
-      `${getBackendUrl()}/getProjectStats?project_name=${project_name}`,
+      `${getBackendUrl()}/getProjectStats?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {
@@ -40,7 +42,9 @@ export default withCourseOwnerOrAdminAccess()(handler)
 export async function getProjectStats(project_name: string) {
   try {
     const response = await fetch(
-      `/api/UIUC-api/getProjectStats?project_name=${project_name}`,
+      `/api/UIUC-api/getProjectStats?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getWeeklyTrends.ts
+++ b/src/pages/api/UIUC-api/getWeeklyTrends.ts
@@ -13,7 +13,9 @@ async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${getBackendUrl()}/getWeeklyTrends?project_name=${project_name}`,
+      `${getBackendUrl()}/getWeeklyTrends?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {
@@ -45,7 +47,9 @@ interface WeeklyTrend {
 export async function getWeeklyTrends(project_name: string) {
   try {
     const response = await fetch(
-      `/api/UIUC-api/getWeeklyTrends?project_name=${project_name}`,
+      `/api/UIUC-api/getWeeklyTrends?project_name=${encodeURIComponent(
+        project_name,
+      )}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/getNomicMapForQueries.ts
+++ b/src/pages/api/getNomicMapForQueries.ts
@@ -15,7 +15,9 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
     // Example response:  {'map_id': 'iframef4967ad7-ff37-4098-ad06-7e1e1a93dd93', 'map_link': 'https://atlas.nomic.ai/map/ed222613-97d9-46a9-8755-12bbc8a06e3a/f4967ad7-ff37-4098-ad06-7e1e1a93dd93'}
     const response = await fetch(
-      `${getBackendUrl()}/getNomicMap?course_name=${course_name}&map_type=${map_type}`,
+      `${getBackendUrl()}/getNomicMap?course_name=${encodeURIComponent(
+        (course_name || '') as string,
+      )}&map_type=${map_type}`,
     )
     const data = await response.json()
 

--- a/src/pages/util/downloadConversationHistory.ts
+++ b/src/pages/util/downloadConversationHistory.ts
@@ -8,7 +8,9 @@ export default async function downloadConversationHistory(
 ): Promise<DownloadResult> {
   try {
     const response = await fetch(
-      `/api/UIUC-api/downloadConvoHistory?course_name=${courseName}`,
+      `/api/UIUC-api/downloadConvoHistory?course_name=${encodeURIComponent(
+        courseName,
+      )}`,
       { method: 'GET' },
     )
 

--- a/src/pages/util/handleExport.ts
+++ b/src/pages/util/handleExport.ts
@@ -9,7 +9,9 @@ export default async function handleExport(
 ): Promise<ExportResult> {
   try {
     const response = await fetch(
-      `/api/UIUC-api/exportAllDocuments?course_name=${course_name}`,
+      `/api/UIUC-api/exportAllDocuments?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
       { method: 'GET' },
     )
 

--- a/src/utils/__tests__/apiUtils.test.ts
+++ b/src/utils/__tests__/apiUtils.test.ts
@@ -12,6 +12,7 @@ import {
   getBackendUrl,
   getBaseUrl,
   uploadToS3,
+  checkCourseNameValid,
 } from '../apiUtils'
 
 describe('apiUtils (browser/jsdom)', () => {
@@ -171,6 +172,35 @@ describe('apiUtils (browser/jsdom)', () => {
     await expect(
       createProject('p', undefined, 'owner@example.com', false),
     ).resolves.toBe(true)
+  })
+
+  describe('checkCourseNameValid', () => {
+    it('should return true for valid course names', () => {
+      expect(checkCourseNameValid('CS101')).toBe(true)
+      expect(checkCourseNameValid('Intro-to-CS-101')).toBe(true)
+    })
+
+    it('should return false for course names containing spaces', () => {
+      expect(checkCourseNameValid('Intro to CS')).toBe(false)
+      expect(checkCourseNameValid('CS101 ')).toBe(false)
+    })
+
+    it('should return false for course names containing underscores', () => {
+      expect(checkCourseNameValid('Intro_to_CS')).toBe(false)
+    })
+
+    it('should return false for course names starting with a hyphen', () => {
+      expect(checkCourseNameValid('-Intro-to-CS-101')).toBe(false)
+    })
+
+    it('should return false for course names containing special characters', () => {
+      expect(checkCourseNameValid('Intro-To-CS&Programming')).toBe(false)
+      expect(checkCourseNameValid('CS@101')).toBe(false)
+    })
+
+    it('should return false for an empty string', () => {
+      expect(checkCourseNameValid('')).toBe(false)
+    })
   })
 
   it('createProject throws an error containing status and error fields', async () => {

--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -320,6 +320,13 @@ export default {
   fetchPresignedUrl,
   fetchCourseMetadata,
 }
+
+// Allow only letters, numbers, and hyphens in course names
+const regex = /^[a-zA-Z0-9-]+$/
+export const checkCourseNameValid = (courseName: string): boolean => {
+  return regex.test(courseName)
+}
+
 /**
  * Create a new project
  * @param project_name - The name of the project

--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -162,7 +162,7 @@ export async function fetchPresignedUrl(
  */
 export async function fetchCourseMetadata(course_name: string): Promise<any> {
   try {
-    const endpoint = `${getBaseUrl()}/api/UIUC-api/getCourseMetadata?course_name=${course_name}`
+    const endpoint = `${getBaseUrl()}/api/UIUC-api/getCourseMetadata?course_name=${encodeURIComponent(course_name)}`
     const response = await fetch(endpoint)
 
     if (!response.ok) {

--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -321,8 +321,8 @@ export default {
   fetchCourseMetadata,
 }
 
-// Allow only letters, numbers, and hyphens in course names
-const regex = /^[a-zA-Z0-9-]+$/
+// Allow only letters, numbers, and hyphens in course names, cannot start with a hyphen, and must be at least 1 character long
+const regex = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/
 export const checkCourseNameValid = (courseName: string): boolean => {
   return regex.test(courseName)
 }

--- a/src/utils/downloadConversationHistory.ts
+++ b/src/utils/downloadConversationHistory.ts
@@ -8,7 +8,9 @@ export const downloadConversationHistory = async (
 ): Promise<DownloadResult> => {
   try {
     const response = await fetch(
-      `/api/UIUC-api/downloadConvoHistory?course_name=${courseName}`,
+      `/api/UIUC-api/downloadConvoHistory?course_name=${encodeURIComponent(
+        courseName,
+      )}`,
       { method: 'GET' },
     )
 

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -125,21 +125,13 @@ export async function handleFunctionCall(
           } catch (fixError) {
             // If healing fails, throw error with context
             throw new Error(
-              `Failed to parse tool arguments: ${
-                parseError instanceof Error
-                  ? parseError.message
-                  : String(parseError)
-              }. Original arguments: ${args.substring(0, 200)}`,
+              `Failed to parse tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}. Original arguments: ${args.substring(0, 200)}`,
             )
           }
         }
         // If not healable, throw error
         throw new Error(
-          `Failed to parse tool arguments: ${
-            parseError instanceof Error
-              ? parseError.message
-              : String(parseError)
-          }. Arguments: ${args.substring(0, 200)}`,
+          `Failed to parse tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}. Arguments: ${args.substring(0, 200)}`,
         )
       }
     }
@@ -335,12 +327,8 @@ const callN8nFunction = async (
   // get n8n api key per project
   if (!n8n_api_key) {
     const url = base_url
-      ? `${base_url}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
-          projectName,
-        )}`
-      : `/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
-          projectName,
-        )}`
+      ? `${base_url}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(projectName)}`
+      : `/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(projectName)}`
 
     const response = await fetch(url, {
       method: 'GET',
@@ -634,11 +622,7 @@ export async function fetchTools(
   if (!api_key || api_key === 'undefined') {
     try {
       const response = await fetch(
-        `${
-          base_url ? base_url : ''
-        }/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
-          course_name,
-        )}`,
+        `${base_url ? base_url : ''}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(course_name)}`,
         {
           method: 'GET',
         },
@@ -672,9 +656,7 @@ export async function fetchTools(
   if (isClientSide) {
     // Client-side: use our API route
     response = await fetch(
-      `/api/UIUC-api/getN8nWorkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}&course_name=${encodeURIComponent(
-        course_name,
-      )}`,
+      `/api/UIUC-api/getN8nWorkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}&course_name=${encodeURIComponent(course_name)}`,
     )
   } else {
     // Server-side: use direct backend call

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -125,13 +125,21 @@ export async function handleFunctionCall(
           } catch (fixError) {
             // If healing fails, throw error with context
             throw new Error(
-              `Failed to parse tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}. Original arguments: ${args.substring(0, 200)}`,
+              `Failed to parse tool arguments: ${
+                parseError instanceof Error
+                  ? parseError.message
+                  : String(parseError)
+              }. Original arguments: ${args.substring(0, 200)}`,
             )
           }
         }
         // If not healable, throw error
         throw new Error(
-          `Failed to parse tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}. Arguments: ${args.substring(0, 200)}`,
+          `Failed to parse tool arguments: ${
+            parseError instanceof Error
+              ? parseError.message
+              : String(parseError)
+          }. Arguments: ${args.substring(0, 200)}`,
         )
       }
     }
@@ -327,8 +335,12 @@ const callN8nFunction = async (
   // get n8n api key per project
   if (!n8n_api_key) {
     const url = base_url
-      ? `${base_url}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${projectName}`
-      : `/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${projectName}`
+      ? `${base_url}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
+          projectName,
+        )}`
+      : `/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
+          projectName,
+        )}`
 
     const response = await fetch(url, {
       method: 'GET',
@@ -622,7 +634,11 @@ export async function fetchTools(
   if (!api_key || api_key === 'undefined') {
     try {
       const response = await fetch(
-        `${base_url ? base_url : ''}/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${course_name}`,
+        `${
+          base_url ? base_url : ''
+        }/api/UIUC-api/tools/getN8nKeyFromProject?course_name=${encodeURIComponent(
+          course_name,
+        )}`,
         {
           method: 'GET',
         },
@@ -656,7 +672,9 @@ export async function fetchTools(
   if (isClientSide) {
     // Client-side: use our API route
     response = await fetch(
-      `/api/UIUC-api/getN8nWorkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}&course_name=${course_name}`,
+      `/api/UIUC-api/getN8nWorkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}&course_name=${encodeURIComponent(
+        course_name,
+      )}`,
     )
   } else {
     // Server-side: use direct backend call

--- a/src/utils/handleExport.ts
+++ b/src/utils/handleExport.ts
@@ -9,7 +9,9 @@ export const handleExport = async (
 ): Promise<ExportResult> => {
   try {
     const response = await fetch(
-      `/api/UIUC-api/exportAllDocuments?course_name=${course_name}`,
+      `/api/UIUC-api/exportAllDocuments?course_name=${encodeURIComponent(
+        course_name,
+      )}`,
       { method: 'GET' },
     )
 


### PR DESCRIPTION
Major change: **Encode course_name and project_name at all places with direct usage in URL**

- Check for valid course name (alpha numeric and hyphens only, cannot start with hyphens) on client and server side
- Trigger exists check only if course name is valid
- Replace all API calls to getCourseExists with useFetchCourseExists hook (URI components are always encoded)
- Normalize course name to lowercase during creation on client and server side
- Encode course exists
- Encode getCourseMetadata
- Replace getCourseMetadata calls with useFetchCourseMetadata