### PR TITLE
Fix/chat api respect vector engine

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -74,6 +74,11 @@ KEYCLOAK_DB_DATABASE=postgres
 # =============================================================================
 # VECTOR DB CONFIGURATION
 # =============================================================================
+# Retrieval engine for /api/getContexts, /api/chat-api/chat, and agent mode.
+# - unset or any value other than "qdrant" → frontend Drizzle + pgvector (default)
+# - "qdrant" → Python backend /getTopContexts (Qdrant)
+# VECTOR_ENGINE=qdrant
+
 QDRANT_API_KEY="your-strong-key-here"
 QDRANT_COLLECTION_NAME=uiuc-chat
 QDRANT_URL=http://localhost:6333

--- a/__tests__/pages/api/__tests__/getContexts.test.ts
+++ b/__tests__/pages/api/__tests__/getContexts.test.ts
@@ -1,10 +1,10 @@
 /* @vitest-environment node */
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createMockReq, createMockRes } from '~/test-utils/nextApi'
 
 const hoisted = vi.hoisted(() => ({
-  fetchContextsViaDrizzleVectorSearch: vi.fn(),
+  fetchContextsByVectorEngine: vi.fn(),
 }))
 
 vi.mock('~/pages/api/authorization', () => ({
@@ -13,14 +13,17 @@ vi.mock('~/pages/api/authorization', () => ({
       h,
 }))
 
-vi.mock('~/server/fetchContextsForVectorSearch', () => ({
-  fetchContextsViaDrizzleVectorSearch:
-    hoisted.fetchContextsViaDrizzleVectorSearch,
+vi.mock('~/utils/fetchContexts', () => ({
+  fetchContextsByVectorEngine: hoisted.fetchContextsByVectorEngine,
 }))
 
 import getContextsHandler from '~/pages/api/getContexts'
 
 describe('getContexts API', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('returns 405 for non-POST methods', async () => {
     const res = createMockRes()
     await getContextsHandler(
@@ -44,7 +47,7 @@ describe('getContexts API', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'course_name and search_query are required',
     })
-    expect(hoisted.fetchContextsViaDrizzleVectorSearch).not.toHaveBeenCalled()
+    expect(hoisted.fetchContextsByVectorEngine).not.toHaveBeenCalled()
   })
 
   it('returns 400 when search_query is missing', async () => {
@@ -60,15 +63,15 @@ describe('getContexts API', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'course_name and search_query are required',
     })
-    expect(hoisted.fetchContextsViaDrizzleVectorSearch).not.toHaveBeenCalled()
+    expect(hoisted.fetchContextsByVectorEngine).not.toHaveBeenCalled()
   })
 
-  it('returns 200 with contexts when fetchContextsViaDrizzleVectorSearch succeeds', async () => {
+  it('returns 200 with contexts when fetchContextsByVectorEngine succeeds', async () => {
     const data = [
       { id: '1', text: 'context 1', metadata: {} },
       { id: '2', text: 'context 2', metadata: {} },
     ]
-    hoisted.fetchContextsViaDrizzleVectorSearch.mockResolvedValueOnce(data)
+    hoisted.fetchContextsByVectorEngine.mockResolvedValueOnce(data)
 
     const res = createMockRes()
     await getContextsHandler(
@@ -77,6 +80,7 @@ describe('getContexts API', () => {
         body: {
           course_name: 'CS225',
           search_query: 'binary trees',
+          token_limit: 2000,
           doc_groups: ['lectures'],
           conversation_id: 'conv-1',
           top_n: 50,
@@ -85,9 +89,10 @@ describe('getContexts API', () => {
       res as any,
     )
 
-    expect(hoisted.fetchContextsViaDrizzleVectorSearch).toHaveBeenCalledWith(
+    expect(hoisted.fetchContextsByVectorEngine).toHaveBeenCalledWith(
       'CS225',
       'binary trees',
+      2000,
       ['lectures'],
       'conv-1',
       50,
@@ -96,8 +101,8 @@ describe('getContexts API', () => {
     expect(res.json).toHaveBeenCalledWith(data)
   })
 
-  it('passes default doc_groups and top_n when omitted from body', async () => {
-    hoisted.fetchContextsViaDrizzleVectorSearch.mockResolvedValueOnce([])
+  it('passes default token_limit, doc_groups and top_n when omitted from body', async () => {
+    hoisted.fetchContextsByVectorEngine.mockResolvedValueOnce([])
 
     const res = createMockRes()
     await getContextsHandler(
@@ -108,9 +113,10 @@ describe('getContexts API', () => {
       res as any,
     )
 
-    expect(hoisted.fetchContextsViaDrizzleVectorSearch).toHaveBeenCalledWith(
+    expect(hoisted.fetchContextsByVectorEngine).toHaveBeenCalledWith(
       'CS101',
       'hello',
+      4000,
       [],
       undefined,
       100,
@@ -118,9 +124,9 @@ describe('getContexts API', () => {
     expect(res.status).toHaveBeenCalledWith(200)
   })
 
-  it('returns 500 when fetchContextsViaDrizzleVectorSearch throws', async () => {
+  it('returns 500 when fetchContextsByVectorEngine throws', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    hoisted.fetchContextsViaDrizzleVectorSearch.mockRejectedValueOnce(
+    hoisted.fetchContextsByVectorEngine.mockRejectedValueOnce(
       new Error('db error'),
     )
 

--- a/src/pages/api/getContexts.ts
+++ b/src/pages/api/getContexts.ts
@@ -1,8 +1,7 @@
 import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { withCourseAccessFromRequest } from '~/pages/api/authorization'
-import fetchContextsFromBackend from '~/utils/fetchContexts'
-import { fetchContextsViaDrizzleVectorSearch } from '~/server/fetchContextsForVectorSearch'
+import { fetchContextsByVectorEngine } from '~/utils/fetchContexts'
 
 export default withCourseAccessFromRequest('any')(handler)
 
@@ -29,22 +28,14 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
       })
     }
 
-    const data =
-      process.env.VECTOR_ENGINE === 'qdrant'
-        ? await fetchContextsFromBackend(
-            course_name,
-            search_query,
-            token_limit,
-            doc_groups,
-            conversation_id,
-          )
-        : await fetchContextsViaDrizzleVectorSearch(
-            course_name,
-            search_query,
-            doc_groups,
-            conversation_id,
-            top_n,
-          )
+    const data = await fetchContextsByVectorEngine(
+      course_name,
+      search_query,
+      token_limit,
+      doc_groups,
+      conversation_id,
+      top_n,
+    )
 
     return res.status(200).json(data)
   } catch (error) {

--- a/src/server/agent/agentServerUtils.ts
+++ b/src/server/agent/agentServerUtils.ts
@@ -14,7 +14,7 @@ import {
 } from '~/types/chat'
 import { decryptKeyIfNeeded } from '~/utils/crypto'
 import { runN8nFlowBackend } from '~/pages/api/UIUC-api/runN8nFlow'
-import fetchContextsFromBackend from '~/utils/fetchContexts'
+import { fetchContextsByVectorEngine } from '~/utils/fetchContexts'
 import { getBackendUrl } from '~/utils/apiUtils'
 import { generatePresignedUrl } from '~/pages/api/download'
 // Reuse existing functions instead of duplicating
@@ -393,12 +393,13 @@ export async function fetchContextsServer(
         return []
       }
 
-      const contexts = await fetchContextsFromBackend(
+      const contexts = await fetchContextsByVectorEngine(
         courseName,
         searchQuery,
         tokenLimit,
         docGroups,
         conversationId,
+        100,
         signal,
       )
 

--- a/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
+++ b/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
@@ -1,0 +1,108 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  fetchContextsViaDrizzleVectorSearch: vi.fn(),
+  getBackendUrl: vi.fn(() => 'https://backend.example'),
+}))
+
+vi.mock('~/server/fetchContextsForVectorSearch', () => ({
+  fetchContextsViaDrizzleVectorSearch:
+    hoisted.fetchContextsViaDrizzleVectorSearch,
+}))
+
+vi.mock('~/utils/apiUtils', () => ({
+  getBackendUrl: hoisted.getBackendUrl,
+}))
+
+import {
+  fetchContexts,
+  fetchContextsByVectorEngine,
+  useQdrantVectorEngine,
+} from '~/utils/fetchContexts'
+
+describe('fetchContextsByVectorEngine / VECTOR_ENGINE routing', () => {
+  const originalEngine = process.env.VECTOR_ENGINE
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.VECTOR_ENGINE
+  })
+
+  afterEach(() => {
+    if (originalEngine === undefined) {
+      delete process.env.VECTOR_ENGINE
+    } else {
+      process.env.VECTOR_ENGINE = originalEngine
+    }
+  })
+
+  it('useQdrantVectorEngine is false when VECTOR_ENGINE is unset', () => {
+    expect(useQdrantVectorEngine()).toBe(false)
+  })
+
+  it('useQdrantVectorEngine is true only when VECTOR_ENGINE=qdrant', () => {
+    process.env.VECTOR_ENGINE = 'qdrant'
+    expect(useQdrantVectorEngine()).toBe(true)
+  })
+
+  it('defaults to Drizzle/pgvector when VECTOR_ENGINE is unset', async () => {
+    const data = [{ id: 1 }]
+    hoisted.fetchContextsViaDrizzleVectorSearch.mockResolvedValueOnce(data)
+
+    const result = await fetchContextsByVectorEngine(
+      'cardiology',
+      'FAI cutoff',
+      4000,
+      [],
+      undefined,
+      100,
+    )
+
+    expect(hoisted.fetchContextsViaDrizzleVectorSearch).toHaveBeenCalledWith(
+      'cardiology',
+      'FAI cutoff',
+      [],
+      undefined,
+      100,
+    )
+    expect(result).toEqual(data)
+  })
+
+  it('calls Qdrant backend when VECTOR_ENGINE=qdrant', async () => {
+    process.env.VECTOR_ENGINE = 'qdrant'
+    const data = [{ id: 2 }]
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(data), { status: 200 }),
+      )
+
+    const result = await fetchContextsByVectorEngine(
+      'cardiology',
+      'FAI cutoff',
+      4000,
+      ['g1'],
+      'conv-1',
+      50,
+    )
+
+    expect(hoisted.fetchContextsViaDrizzleVectorSearch).not.toHaveBeenCalled()
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://backend.example/getTopContexts',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(result).toEqual(data)
+  })
+
+  it('server-side fetchContexts uses VECTOR_ENGINE routing (pgvector by default)', async () => {
+    const data = [{ id: 3 }]
+    hoisted.fetchContextsViaDrizzleVectorSearch.mockResolvedValueOnce(data)
+
+    const result = await fetchContexts('cardiology', 'query', 4000, [], 'c1')
+
+    expect(hoisted.fetchContextsViaDrizzleVectorSearch).toHaveBeenCalled()
+    expect(result).toEqual(data)
+  })
+})

--- a/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
+++ b/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
@@ -19,7 +19,7 @@ vi.mock('~/utils/apiUtils', () => ({
 import {
   fetchContexts,
   fetchContextsByVectorEngine,
-  useQdrantVectorEngine,
+  isQdrantVectorEngine,
 } from '~/utils/fetchContexts'
 
 describe('fetchContextsByVectorEngine / VECTOR_ENGINE routing', () => {
@@ -38,13 +38,13 @@ describe('fetchContextsByVectorEngine / VECTOR_ENGINE routing', () => {
     }
   })
 
-  it('useQdrantVectorEngine is false when VECTOR_ENGINE is unset', () => {
-    expect(useQdrantVectorEngine()).toBe(false)
+  it('isQdrantVectorEngine is false when VECTOR_ENGINE is unset', () => {
+    expect(isQdrantVectorEngine()).toBe(false)
   })
 
-  it('useQdrantVectorEngine is true only when VECTOR_ENGINE=qdrant', () => {
+  it('isQdrantVectorEngine is true only when VECTOR_ENGINE=qdrant', () => {
     process.env.VECTOR_ENGINE = 'qdrant'
-    expect(useQdrantVectorEngine()).toBe(true)
+    expect(isQdrantVectorEngine()).toBe(true)
   })
 
   it('defaults to Drizzle/pgvector when VECTOR_ENGINE is unset', async () => {

--- a/src/utils/fetchContexts.ts
+++ b/src/utils/fetchContexts.ts
@@ -2,7 +2,7 @@ import { type ContextWithMetadata } from '~/types/chat'
 import { getBackendUrl } from '~/utils/apiUtils'
 
 /** True when VECTOR_ENGINE is explicitly set to qdrant; otherwise use pgvector (Drizzle). */
-export function useQdrantVectorEngine(): boolean {
+export function isQdrantVectorEngine(): boolean {
   return process.env.VECTOR_ENGINE === 'qdrant'
 }
 
@@ -58,7 +58,7 @@ export async function fetchContextsByVectorEngine(
   top_n = 100,
   signal?: AbortSignal,
 ): Promise<ContextWithMetadata[]> {
-  if (useQdrantVectorEngine()) {
+  if (isQdrantVectorEngine()) {
     return fetchContextsFromBackend(
       course_name,
       search_query,

--- a/src/utils/fetchContexts.ts
+++ b/src/utils/fetchContexts.ts
@@ -1,6 +1,11 @@
 import { type ContextWithMetadata } from '~/types/chat'
 import { getBackendUrl } from '~/utils/apiUtils'
 
+/** True when VECTOR_ENGINE is explicitly set to qdrant; otherwise use pgvector (Drizzle). */
+export function useQdrantVectorEngine(): boolean {
+  return process.env.VECTOR_ENGINE === 'qdrant'
+}
+
 // Common function to fetch contexts from backend - can be used anywhere
 export default async function fetchContextsFromBackend(
   course_name: string,
@@ -37,6 +42,45 @@ export default async function fetchContextsFromBackend(
   return data
 }
 
+/**
+ * Server-side retrieval routed by VECTOR_ENGINE.
+ * - VECTOR_ENGINE=qdrant → Python /getTopContexts (Qdrant)
+ * - unset / anything else → frontend Drizzle + pgvector
+ *
+ * Used by /api/getContexts, chat-api (via fetchContexts), and agent mode.
+ */
+export async function fetchContextsByVectorEngine(
+  course_name: string,
+  search_query: string,
+  token_limit = 4000,
+  doc_groups: string[] = [],
+  conversation_id?: string,
+  top_n = 100,
+  signal?: AbortSignal,
+): Promise<ContextWithMetadata[]> {
+  if (useQdrantVectorEngine()) {
+    return fetchContextsFromBackend(
+      course_name,
+      search_query,
+      token_limit,
+      doc_groups,
+      conversation_id,
+      signal,
+    )
+  }
+
+  const { fetchContextsViaDrizzleVectorSearch } = await import(
+    '~/server/fetchContextsForVectorSearch'
+  )
+  return fetchContextsViaDrizzleVectorSearch(
+    course_name,
+    search_query,
+    doc_groups,
+    conversation_id,
+    top_n,
+  )
+}
+
 // Helper function for use in components/utilities
 export const fetchContexts = async (
   course_name: string,
@@ -50,7 +94,7 @@ export const fetchContexts = async (
 
   try {
     if (isClientSide) {
-      // Client-side: use our API route
+      // Client-side: use our API route (which also respects VECTOR_ENGINE)
       const response = await fetch(
         `${window.location.origin}/api/getContexts`,
         {
@@ -76,8 +120,8 @@ export const fetchContexts = async (
       const data: ContextWithMetadata[] = await response.json()
       return data
     } else {
-      // Server-side: use the common function directly
-      return await fetchContextsFromBackend(
+      // Server-side (e.g. chat-api): same VECTOR_ENGINE routing as /api/getContexts
+      return await fetchContextsByVectorEngine(
         course_name,
         search_query,
         token_limit,


### PR DESCRIPTION
- Route all server-side retrieval (including /api/chat-api/chat and agent mode) through the same VECTOR_ENGINE flag as /api/getContexts
- Unset / non-qdrant → Drizzle + pgvector; VECTOR_ENGINE=qdrant → Python /getTopContexts
- Fixes chat-api always hitting Qdrant (and failing when qdrant_client isn’t available)